### PR TITLE
Potential fix for code scanning alert no. 36: Uncontrolled data used in path expression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django>=5.2,<5.3
+Werkzeug==3.1.5
 python-dotenv==1.0.0
 python-magic==0.4.27
 Pillow>=11.0.0, <12.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/gdsanger/KManager/security/code-scanning/36](https://github.com/gdsanger/KManager/security/code-scanning/36)

In general, the fix is to ensure that any path derived from untrusted input is (a) normalized and (b) verified to remain inside an intended base directory before being used. For filenames, it is also common to sanitize the name itself (for example, removing path separators and dangerous characters) to prevent traversal or unintended directory creation.

For this specific code, the safest minimal change without altering behavior is:

1. Sanitize `logo_file.name` into a safe filename that does not contain path separators and strips unsafe characters. We can use `werkzeug.utils.secure_filename`, a well-known library function specifically intended for this.
2. Use the sanitized filename when constructing the final `full_path`.
3. Normalize the constructed path with `os.path.normpath` and verify that it is still within `settings.MEDIA_ROOT/mandants` before opening it. This defends against any remaining edge cases.

Concretely in `core/views.py` inside `mandant_detail`:

- Add `from werkzeug.utils import secure_filename` to the imports at the top (we are allowed to add imports of well-known external libraries).
- At the logo upload section:
  - Before building `filename`, compute `safe_logo_name = secure_filename(logo_file.name)`.
  - Build `filename` using `safe_logo_name` instead of `logo_file.name`.
  - Define `mandants_dir = os.path.join(settings.MEDIA_ROOT, 'mandants')` (already present).
  - Build `relative_path` as before.
  - Compute `full_path = os.path.normpath(os.path.join(settings.MEDIA_ROOT, relative_path))`.
  - Verify that `full_path` starts with the normalized `mandants_dir` path (using `os.path.commonpath`) and, if not, reject the upload with an error message and redirect.
- Keep the rest of the behavior (overwriting old logo, saving the Mandant, etc.) unchanged.

This preserves existing functionality (same directory, same naming semantics except that unsafe characters are stripped/normalized) while guaranteeing that `full_path` cannot escape the intended upload directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
