### PR TITLE
[#721 Sub 1/4] Backend-Härtung Line-Save (ajax_update_line/ajax_add_line) — Sofortmaßnahme

### DIFF
--- a/auftragsverwaltung/test_line_save_hardening.py
+++ b/auftragsverwaltung/test_line_save_hardening.py
@@ -1,0 +1,314 @@
+"""
+Regression tests for Issue #721 Sub 1/4: Backend-Haertung Line-Save
+(ajax_update_line / ajax_add_line).
+
+Covers the root causes identified in the issue:
+1. Overlapping saves of the same line must not lose concurrently written fields
+   (no more last-writer-wins from a full-row save() without update_fields).
+2. German/empty/invalid decimal input must return HTTP 400, never HTTP 500,
+   and must never discard the other fields of the same request.
+3. A corrupted/truncated JSON body must not be silently treated as an empty,
+   successfully-applied payload.
+4. An empty or fully-unrecognized payload must not report success:True.
+5. Invalid tax_rate_id/item_id must return a clear 400 instead of a bare
+   Http404-as-500, without corrupting the line.
+"""
+from django.test import TestCase, Client
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+from django.db.models.signals import pre_save
+from decimal import Decimal
+from datetime import date
+import json
+
+from auftragsverwaltung.models import (
+    SalesDocument, SalesDocumentLine, DocumentType, NumberRange
+)
+from core.models import Mandant, Adresse, TaxRate, PaymentTerm
+
+User = get_user_model()
+
+
+class LineSaveHardeningTestCase(TestCase):
+    """Shared fixtures for line-save hardening tests"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            password='testpass123'
+        )
+        self.client = Client()
+        self.client.login(username='testuser', password='testpass123')
+
+        self.company = Mandant.objects.create(
+            name='Test Company GmbH',
+            adresse='Teststraße 123',
+            plz='12345',
+            ort='Teststadt',
+            land='Deutschland',
+            steuernummer='DE123456789'
+        )
+        self.customer = Adresse.objects.create(
+            adressen_type='KUNDE',
+            name='Test Customer',
+            anrede='Herr',
+            strasse='Kundenstraße 1',
+            plz='54321',
+            ort='Kundenstadt',
+            land='Deutschland'
+        )
+        self.tax_rate = TaxRate.objects.create(
+            code='STANDARD',
+            name='Standard-Steuersatz',
+            rate=Decimal('0.19'),
+            is_active=True
+        )
+        self.payment_term = PaymentTerm.objects.create(
+            name='14 Tage netto',
+            net_days=14,
+            is_default=False
+        )
+        self.doc_type_invoice, _ = DocumentType.objects.get_or_create(
+            key='invoice',
+            defaults={
+                'name': 'Rechnung',
+                'prefix': 'RE',
+                'is_invoice': True,
+                'is_active': True
+            }
+        )
+        NumberRange.objects.create(
+            company=self.company,
+            target='DOCUMENT',
+            document_type=self.doc_type_invoice,
+            reset_policy='YEARLY',
+            format='{prefix}{yy}-{seq:05d}'
+        )
+        self.document = SalesDocument.objects.create(
+            company=self.company,
+            document_type=self.doc_type_invoice,
+            number='RE-2024-1001',
+            status='DRAFT',
+            customer=self.customer,
+            payment_term=self.payment_term,
+            issue_date=date.today(),
+            total_net=Decimal('0.00'),
+            total_tax=Decimal('0.00'),
+            total_gross=Decimal('0.00')
+        )
+        self.line = SalesDocumentLine.objects.create(
+            document=self.document,
+            position_no=1,
+            line_type='NORMAL',
+            is_selected=True,
+            short_text_1='Original Kurztext',
+            short_text_2='Original Kurztext 2',
+            long_text='Original long text',
+            description='Test Item',
+            quantity=Decimal('1.0000'),
+            unit_price_net=Decimal('100.00'),
+            tax_rate=self.tax_rate,
+            is_discountable=True,
+            discount=Decimal('0.00'),
+            line_net=Decimal('100.00'),
+            line_tax=Decimal('19.00'),
+            line_gross=Decimal('119.00')
+        )
+        self.update_url = reverse(
+            'auftragsverwaltung:ajax_update_line',
+            kwargs={'doc_key': 'invoice', 'pk': self.document.pk, 'line_id': self.line.pk}
+        )
+        self.add_url = reverse(
+            'auftragsverwaltung:ajax_add_line',
+            kwargs={'doc_key': 'invoice', 'pk': self.document.pk}
+        )
+
+    def _post_json(self, url, data):
+        return self.client.post(url, data=json.dumps(data), content_type='application/json')
+
+
+class OverlappingSaveTestCase(LineSaveHardeningTestCase):
+    """Root cause #1: full-row save() without update_fields loses concurrent edits"""
+
+    def test_update_does_not_clobber_field_changed_concurrently(self):
+        """
+        Simulate another request writing short_text_2 directly to the DB in the
+        window between our view reading the line and saving it. With update_fields
+        scoped to only the fields this request actually touched, the concurrently
+        written field must survive.
+        """
+        simulated = {'done': False}
+
+        def simulate_concurrent_write(sender, instance, **kwargs):
+            if instance.pk == self.line.pk and not simulated['done']:
+                SalesDocumentLine.objects.filter(pk=self.line.pk).update(
+                    short_text_2='ChangedByConcurrentRequest'
+                )
+                simulated['done'] = True
+
+        pre_save.connect(simulate_concurrent_write, sender=SalesDocumentLine)
+        try:
+            response = self._post_json(self.update_url, {'short_text_1': 'Updated By Us'})
+        finally:
+            pre_save.disconnect(simulate_concurrent_write, sender=SalesDocumentLine)
+
+        self.assertEqual(response.status_code, 200, response.content)
+        self.assertTrue(json.loads(response.content)['success'])
+
+        self.line.refresh_from_db()
+        self.assertEqual(self.line.short_text_1, 'Updated By Us')
+        self.assertEqual(
+            self.line.short_text_2, 'ChangedByConcurrentRequest',
+            "Concurrently written field must not be clobbered by our stale in-memory value"
+        )
+
+
+class DecimalHardeningTestCase(LineSaveHardeningTestCase):
+    """Root cause #2: raw Decimal() parsing crashes on German/empty/invalid input"""
+
+    def test_update_german_quantity_and_price_succeeds(self):
+        response = self._post_json(self.update_url, {'quantity': '2,500', 'unit_price_net': '49,90'})
+        self.assertEqual(response.status_code, 200, response.content)
+        self.line.refresh_from_db()
+        self.assertEqual(self.line.quantity, Decimal('2.500'))
+        self.assertEqual(self.line.unit_price_net, Decimal('49.90'))
+
+    def test_update_invalid_quantity_returns_400_not_500(self):
+        response = self._post_json(self.update_url, {'quantity': 'abc', 'short_text_1': 'Should Not Save'})
+        self.assertEqual(response.status_code, 400, response.content)
+        body = json.loads(response.content)
+        self.assertFalse(body.get('success'))
+        self.assertIn('Menge', body['error'])
+
+        self.line.refresh_from_db()
+        self.assertEqual(self.line.short_text_1, 'Original Kurztext')
+
+    def test_update_invalid_price_returns_400_not_500(self):
+        response = self._post_json(self.update_url, {'unit_price_net': ''})
+        self.assertEqual(response.status_code, 400, response.content)
+        body = json.loads(response.content)
+        self.assertFalse(body.get('success'))
+        self.assertIn('Stückpreis', body['error'])
+
+    def test_update_invalid_discount_returns_400(self):
+        response = self._post_json(self.update_url, {'discount': 'xyz'})
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Rabatt', json.loads(response.content)['error'])
+
+    def test_add_line_german_decimal_succeeds(self):
+        response = self._post_json(self.add_url, {
+            'short_text_1': 'Neue Position',
+            'quantity': '3,000',
+            'unit_price_net': '19,99',
+            'tax_rate_id': self.tax_rate.pk,
+        })
+        self.assertEqual(response.status_code, 200, response.content)
+        data = json.loads(response.content)
+        self.assertTrue(data['success'])
+        line = SalesDocumentLine.objects.get(pk=data['line_id'])
+        self.assertEqual(line.quantity, Decimal('3.000'))
+        self.assertEqual(line.unit_price_net, Decimal('19.99'))
+
+    def test_add_line_invalid_quantity_returns_400_not_500(self):
+        response = self._post_json(self.add_url, {
+            'short_text_1': 'Neue Position',
+            'quantity': 'invalid',
+            'unit_price_net': '10.00',
+            'tax_rate_id': self.tax_rate.pk,
+        })
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Menge', json.loads(response.content)['error'])
+
+    def test_add_line_invalid_price_returns_400_not_500(self):
+        response = self._post_json(self.add_url, {
+            'short_text_1': 'Neue Position',
+            'quantity': '1',
+            'unit_price_net': 'not-a-number',
+            'tax_rate_id': self.tax_rate.pk,
+        })
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Stückpreis', json.loads(response.content)['error'])
+
+    def test_add_line_invalid_discount_returns_400(self):
+        response = self._post_json(self.add_url, {
+            'short_text_1': 'Neue Position',
+            'quantity': '1',
+            'unit_price_net': '10.00',
+            'tax_rate_id': self.tax_rate.pk,
+            'discount': 'garbage',
+        })
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Rabatt', json.loads(response.content)['error'])
+
+
+class PayloadHardeningTestCase(LineSaveHardeningTestCase):
+    """Root cause #3/#4: corrupted or empty payloads must not report success:True"""
+
+    def test_corrupted_json_body_returns_400_not_silent_success(self):
+        response = self.client.post(
+            self.update_url,
+            data='{"short_text_1": "trunc',  # deliberately broken JSON
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 400, response.content)
+        body = json.loads(response.content)
+        self.assertFalse(body.get('success'))
+
+        self.line.refresh_from_db()
+        self.assertEqual(self.line.short_text_1, 'Original Kurztext')
+
+    def test_empty_json_object_returns_400_not_success(self):
+        response = self._post_json(self.update_url, {})
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertFalse(json.loads(response.content).get('success'))
+
+    def test_only_unrecognized_keys_returns_400_not_success(self):
+        response = self._post_json(self.update_url, {'not_a_real_field': 'value'})
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertFalse(json.loads(response.content).get('success'))
+
+    def test_empty_add_line_payload_returns_400(self):
+        response = self.client.post(self.add_url, data='', content_type='application/json')
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertFalse(json.loads(response.content).get('success'))
+
+
+class InvalidForeignKeyTestCase(LineSaveHardeningTestCase):
+    """Root cause #5: invalid tax_rate_id/item_id must be a clean 400, not Http404-as-500"""
+
+    def test_update_invalid_tax_rate_id_returns_400(self):
+        response = self._post_json(self.update_url, {'tax_rate_id': 999999, 'short_text_1': 'Should Not Save'})
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Steuersatz', json.loads(response.content)['error'])
+
+        # The whole request is rejected atomically - the valid short_text_1
+        # change is not silently applied together with the invalid tax rate.
+        self.line.refresh_from_db()
+        self.assertEqual(self.line.short_text_1, 'Original Kurztext')
+
+        # Resubmitting without the bad tax_rate_id must succeed.
+        response = self._post_json(self.update_url, {'short_text_1': 'Should Save Now'})
+        self.assertEqual(response.status_code, 200, response.content)
+        self.line.refresh_from_db()
+        self.assertEqual(self.line.short_text_1, 'Should Save Now')
+
+    def test_update_invalid_item_id_returns_400(self):
+        response = self._post_json(self.update_url, {'item_id': 999999})
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Artikel', json.loads(response.content)['error'])
+
+    def test_add_line_invalid_tax_rate_id_returns_400(self):
+        response = self._post_json(self.add_url, {
+            'short_text_1': 'Neue Position',
+            'quantity': '1',
+            'unit_price_net': '10.00',
+            'tax_rate_id': 999999,
+        })
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Steuersatz', json.loads(response.content)['error'])
+
+    def test_add_line_invalid_item_id_returns_400(self):
+        response = self._post_json(self.add_url, {'item_id': 999999})
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn('Artikel', json.loads(response.content)['error'])

--- a/auftragsverwaltung/views.py
+++ b/auftragsverwaltung/views.py
@@ -774,7 +774,8 @@ def ajax_add_line(request, doc_key, pk):
     try:
         quantity = normalize_decimal_input(data.get('quantity', '1.0'))
     except (ValueError, TypeError) as e:
-        return JsonResponse({'success': False, 'error': f'Ungültige Menge: {e}'}, status=400)
+        logger.warning("Ungültige Menge in add-document-line Request.", exc_info=True)
+        return JsonResponse({'success': False, 'error': 'Ungültige Menge.'}, status=400)
 
     try:
         # Determine line data based on whether item is provided

--- a/auftragsverwaltung/views.py
+++ b/auftragsverwaltung/views.py
@@ -1,7 +1,8 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
+from django.db import transaction
 from django.db.models import Q, Sum, Max
-from django.http import JsonResponse, HttpResponse
+from django.http import Http404, JsonResponse, HttpResponse
 from django.views.decorators.http import require_http_methods, require_POST
 from django.conf import settings
 from django.urls import reverse
@@ -733,49 +734,66 @@ def ajax_search_customers(request):
 def ajax_add_line(request, doc_key, pk):
     """
     AJAX endpoint to add a new line to a document
-    
+
     POST parameters (JSON):
         - item_id: Item/Article ID (optional for manual lines)
-        - quantity: Quantity
+        - quantity: Quantity (German or English decimal format)
         - description: Description (required for manual lines)
-        - unit_price_net: Unit price (required for manual lines)
+        - unit_price_net: Unit price (required for manual lines; German or English decimal format)
         - tax_rate_id: Tax rate ID (required)
         - line_type: Line type (NORMAL, OPTIONAL, ALTERNATIVE)
         - kostenart1_id: Kostenart 1 ID (optional)
         - kostenart2_id: Kostenart 2 ID (optional)
-    
+
     Returns:
-        JSON: {success, line_id, line_data}
+        JSON: {success, line_id, line_data} on success.
+        Validation errors (invalid decimal, unknown tax_rate_id/item_id, missing
+        required fields, empty payload) return HTTP 400 with {'success': False, 'error': ...}.
     """
+    document = get_object_or_404(SalesDocument, pk=pk)
+
     try:
-        document = get_object_or_404(SalesDocument, pk=pk)
-        
-        # Parse JSON body
-        data = json.loads(request.body)
-        
-        item_id = data.get('item_id')
-        quantity = Decimal(data.get('quantity', '1.0'))
-        line_type = data.get('line_type', 'NORMAL')
-        description = data.get('description', '')
-        short_text_1 = data.get('short_text_1', '')
-        short_text_2 = data.get('short_text_2', '')
-        long_text = data.get('long_text', '')
-        unit_price_net = data.get('unit_price_net')
-        tax_rate_id = data.get('tax_rate_id')
-        kostenart1_id = data.get('kostenart1_id')
-        kostenart2_id = data.get('kostenart2_id')
-        
+        data = json.loads(request.body) if request.body else {}
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({'success': False, 'error': 'Ungültiger JSON-Body.'}, status=400)
+
+    if not data:
+        return JsonResponse({'success': False, 'error': 'Keine Felder für die neue Position übermittelt.'}, status=400)
+
+    item_id = data.get('item_id')
+    line_type = data.get('line_type', 'NORMAL')
+    description = data.get('description', '')
+    short_text_1 = data.get('short_text_1', '')
+    short_text_2 = data.get('short_text_2', '')
+    long_text = data.get('long_text', '')
+    unit_price_net = data.get('unit_price_net')
+    tax_rate_id = data.get('tax_rate_id')
+    kostenart1_id = data.get('kostenart1_id')
+    kostenart2_id = data.get('kostenart2_id')
+
+    try:
+        quantity = normalize_decimal_input(data.get('quantity', '1.0'))
+    except (ValueError, TypeError) as e:
+        return JsonResponse({'success': False, 'error': f'Ungültige Menge: {e}'}, status=400)
+
+    try:
         # Determine line data based on whether item is provided
         if item_id:
             # Article-based line
-            item = get_object_or_404(Item, pk=item_id)
-            
+            try:
+                item = Item.objects.get(pk=item_id)
+            except Item.DoesNotExist:
+                return JsonResponse(
+                    {'success': False, 'error': f'Ungültiger Artikel: Kein Artikel mit ID {item_id} gefunden.'},
+                    status=400
+                )
+
             # Determine tax rate (using TaxDeterminationService)
             tax_rate = TaxDeterminationService.determine_tax_rate(
                 customer=document.customer,
                 item_tax_rate=item.tax_rate
             )
-            
+
             # Use item data
             if not short_text_1:
                 short_text_1 = item.short_text_1
@@ -788,7 +806,7 @@ def ajax_add_line(request, doc_key, pk):
             if not unit_price_net:
                 unit_price_net = item.net_price
             is_discountable = item.is_discountable
-            
+
             # Use item's kostenart if not provided
             if not kostenart1_id and item.cost_type_1:
                 kostenart1_id = item.cost_type_1.pk
@@ -797,24 +815,23 @@ def ajax_add_line(request, doc_key, pk):
         else:
             # Manual line without item
             item = None
-            
-            # Allow empty positions for initial creation (user will fill them in)
-            # Only validate if we have some non-empty content
-            try:
-                price_value = float(unit_price_net) if unit_price_net else 0.0
-            except (ValueError, TypeError):
-                price_value = 0.0
-            
+
             # Validate mandatory fields only if user has entered description content
             # Allow positions with just short_text_1 and zero price for initial creation
             if description and description.strip():
                 # If user entered description, require short_text_1 too
                 if not short_text_1 or not short_text_1.strip():
-                    return JsonResponse({'error': 'Short text 1 is required when description is provided'}, status=400)
-            
+                    return JsonResponse(
+                        {'success': False, 'error': 'Kurztext 1 ist erforderlich, wenn eine Beschreibung angegeben wird.'},
+                        status=400
+                    )
+
             if not tax_rate_id:
-                return JsonResponse({'error': 'Tax rate is required for manual lines'}, status=400)
-            
+                return JsonResponse(
+                    {'success': False, 'error': 'Steuersatz ist für manuelle Positionen erforderlich.'},
+                    status=400
+                )
+
             # Generate description from short texts if not provided
             if not description and short_text_1:
                 parts = [short_text_1]
@@ -823,87 +840,107 @@ def ajax_add_line(request, doc_key, pk):
                 if long_text:
                     parts.append(long_text)
                 description = '\n'.join(parts)
-            
+
             # Set default empty description if still empty
             if not description:
                 description = ''
-            
-            tax_rate = get_object_or_404(TaxRate, pk=tax_rate_id)
-            unit_price_net = Decimal(unit_price_net) if unit_price_net else Decimal('0.00')
+
+            try:
+                tax_rate = TaxRate.objects.get(pk=tax_rate_id)
+            except TaxRate.DoesNotExist:
+                return JsonResponse(
+                    {'success': False, 'error': f'Ungültiger Steuersatz: Kein Steuersatz mit ID {tax_rate_id} gefunden.'},
+                    status=400
+                )
             is_discountable = data.get('is_discountable', True)
-        
-        # Get next position number
-        max_position = document.lines.aggregate(max_pos=Max('position_no'))['max_pos'] or 0
-        position_no = max_position + 1
-        
+
+        try:
+            if isinstance(unit_price_net, Decimal):
+                unit_price_net_decimal = unit_price_net
+            elif unit_price_net in (None, ''):
+                unit_price_net_decimal = Decimal('0.00')
+            else:
+                unit_price_net_decimal = normalize_decimal_input(unit_price_net)
+        except (ValueError, TypeError) as e:
+            return JsonResponse({'success': False, 'error': f'Ungültiger Netto-Stückpreis: {e}'}, status=400)
+
         # Get unit and discount if provided
         unit_id = data.get('unit_id')
         discount = data.get('discount')
-        
-        # Safely convert discount to Decimal
-        if discount not in (None, ''):
-            try:
-                discount_value = Decimal(str(discount))
-            except (ValueError, TypeError):
-                discount_value = Decimal('0.00')
-        else:
-            discount_value = Decimal('0.00')
-        
-        # Create line
-        line = SalesDocumentLine.objects.create(
-            document=document,
-            item=item,
-            tax_rate=tax_rate,
-            position_no=position_no,
-            line_type=line_type,
-            is_selected=True if line_type == 'NORMAL' else data.get('is_selected', False),
-            short_text_1=short_text_1,
-            short_text_2=short_text_2,
-            long_text=sanitize_html(long_text) if long_text else '',
-            description=description,
-            quantity=quantity,
-            unit_id=normalize_foreign_key_id(unit_id),
-            unit_price_net=unit_price_net,
-            discount=discount_value,
-            is_discountable=is_discountable,
-            kostenart1_id=normalize_foreign_key_id(kostenart1_id),
-            kostenart2_id=normalize_foreign_key_id(kostenart2_id),
-        )
-        
-        # Recalculate document totals
-        DocumentCalculationService.recalculate(document, persist=True)
-        
-        # Return line data
-        return JsonResponse({
-            'success': True,
-            'line_id': line.pk,
-            'line': {
-                'id': line.pk,
-                'position_no': line.position_no,
-                'short_text_1': line.short_text_1,
-                'short_text_2': line.short_text_2,
-                'long_text': line.long_text,
-                'description': line.description,
-                'quantity': str(line.quantity),
-                'unit_id': line.unit.pk if line.unit else None,
-                'unit_price_net': str(line.unit_price_net),
-                'discount': str(line.discount),
-                'tax_rate': str(line.tax_rate.rate),
-                'tax_rate_id': line.tax_rate.pk,
-                'line_net': str(line.line_net),
-                'line_tax': str(line.line_tax),
-                'line_gross': str(line.line_gross),
-                'kostenart1_id': line.kostenart1.pk if line.kostenart1 else None,
-                'kostenart2_id': line.kostenart2.pk if line.kostenart2 else None,
-            },
-            'totals': {
-                'total_net': str(document.total_net),
-                'total_tax': str(document.total_tax),
-                'total_gross': str(document.total_gross),
-            }
-        })
+
+        try:
+            discount_value = (
+                normalize_decimal_input(discount) if discount not in (None, '') else Decimal('0.00')
+            )
+        except (ValueError, TypeError) as e:
+            return JsonResponse({'success': False, 'error': f'Ungültiger Rabatt: {e}'}, status=400)
+
+        with transaction.atomic():
+            # Get next position number
+            max_position = document.lines.aggregate(max_pos=Max('position_no'))['max_pos'] or 0
+            position_no = max_position + 1
+
+            # Create line
+            line = SalesDocumentLine.objects.create(
+                document=document,
+                item=item,
+                tax_rate=tax_rate,
+                position_no=position_no,
+                line_type=line_type,
+                is_selected=True if line_type == 'NORMAL' else data.get('is_selected', False),
+                short_text_1=short_text_1,
+                short_text_2=short_text_2,
+                # long_text is rendered with the `|safe` filter in PDF templates, so it must be
+                # bleach-sanitized. short_text_1/2 and description are always auto-escaped by
+                # Django templates and are stored as plain text, so no sanitization is applied.
+                long_text=sanitize_html(long_text) if long_text else '',
+                description=description,
+                quantity=quantity,
+                unit_id=normalize_foreign_key_id(unit_id),
+                unit_price_net=unit_price_net_decimal,
+                discount=discount_value,
+                is_discountable=is_discountable,
+                kostenart1_id=normalize_foreign_key_id(kostenart1_id),
+                kostenart2_id=normalize_foreign_key_id(kostenart2_id),
+            )
+
+            # Recalculate document totals
+            DocumentCalculationService.recalculate(document, persist=True)
+    except Http404:
+        raise
     except Exception as e:
-        return JsonResponse({'error': str(e)}, status=500)
+        logger.exception(f"Error adding line to document {pk}: {e}")
+        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+
+    # Return line data
+    return JsonResponse({
+        'success': True,
+        'line_id': line.pk,
+        'line': {
+            'id': line.pk,
+            'position_no': line.position_no,
+            'short_text_1': line.short_text_1,
+            'short_text_2': line.short_text_2,
+            'long_text': line.long_text,
+            'description': line.description,
+            'quantity': str(line.quantity),
+            'unit_id': line.unit.pk if line.unit else None,
+            'unit_price_net': str(line.unit_price_net),
+            'discount': str(line.discount),
+            'tax_rate': str(line.tax_rate.rate),
+            'tax_rate_id': line.tax_rate.pk,
+            'line_net': str(line.line_net),
+            'line_tax': str(line.line_tax),
+            'line_gross': str(line.line_gross),
+            'kostenart1_id': line.kostenart1.pk if line.kostenart1 else None,
+            'kostenart2_id': line.kostenart2.pk if line.kostenart2 else None,
+        },
+        'totals': {
+            'total_net': str(document.total_net),
+            'total_tax': str(document.total_tax),
+            'total_gross': str(document.total_gross),
+        }
+    })
 
 
 @login_required
@@ -927,149 +964,239 @@ def ajax_update_line(request, doc_key, pk, line_id):
         - kostenart2_id: New kostenart2 ID
     
     Returns:
-        JSON: {success, line_data, totals}
+        JSON: {success, line_data, totals} on success.
+        Validation errors (invalid decimal, unknown tax_rate_id/item_id, empty or
+        unrecognized payload) return HTTP 400 with {'success': False, 'error': ...}
+        instead of a 500 and never discard the fields that were valid.
     """
-    try:
-        document = get_object_or_404(SalesDocument, pk=pk)
-        line = get_object_or_404(SalesDocumentLine, pk=line_id, document=document)
-        
-        # Parse request data - support both JSON and form-encoded data
-        # HTMX with hx-vals sends form-encoded data, while tests send JSON
+    document = get_object_or_404(SalesDocument, pk=pk)
+
+    # Parse request data - support both JSON and form-encoded data.
+    # HTMX with hx-vals sends form-encoded data, while tests send JSON.
+    # A JSON content-type with an unparsable/truncated body must fail loudly
+    # instead of silently falling back to an empty payload (root cause of the
+    # "success:True but nothing saved" no-op described in Issue #721).
+    content_type = (request.content_type or '').lower()
+    if 'application/json' in content_type:
+        if not request.body:
+            return JsonResponse({'success': False, 'error': 'Leerer Request-Body.'}, status=400)
+        try:
+            data = json.loads(request.body)
+        except (json.JSONDecodeError, ValueError):
+            return JsonResponse({'success': False, 'error': 'Ungültiger JSON-Body.'}, status=400)
+    else:
         try:
             data = json.loads(request.body) if request.body else {}
         except (json.JSONDecodeError, ValueError):
             # Fall back to form-encoded data (from HTMX hx-vals)
             data = request.POST.dict()
-        
-        provided_short_text_1 = 'short_text_1' in data
-        provided_short_text_2 = 'short_text_2' in data
-        provided_long_text = 'long_text' in data
-        provided_description = 'description' in data
-        provided_tax_rate = 'tax_rate_id' in data
-        provided_unit_price = 'unit_price_net' in data
 
-        new_item = None
-        item_changed = False
+    if not data:
+        return JsonResponse({'success': False, 'error': 'Keine Felder zum Aktualisieren übermittelt.'}, status=400)
 
-        # Update fields
-        if 'item_id' in data:
-            item_id = normalize_foreign_key_id(data['item_id'])
-            if item_id is not None:
-                new_item = get_object_or_404(Item, pk=item_id)
-                item_changed = line.item_id != new_item.pk
-                line.item = new_item
-            else:
-                item_changed = line.item_id is not None
-                line.item = None
-        if 'quantity' in data:
-            line.quantity = Decimal(data['quantity'])
-        if 'unit_price_net' in data:
-            line.unit_price_net = Decimal(data['unit_price_net'])
-        if 'short_text_1' in data:
-            line.short_text_1 = data['short_text_1']
-        if 'short_text_2' in data:
-            line.short_text_2 = data['short_text_2']
-        if 'long_text' in data:
-            # Log the update for debugging Issue #377
-            logger.debug(f"Updating long_text for line {line_id}: old_value='{line.long_text}', new_value='{data['long_text']}'")
-            # Sanitize HTML content before saving
-            line.long_text = sanitize_html(data['long_text'])
-        if 'description' in data:
-            line.description = data['description']
-        if 'tax_rate_id' in data:
-            tax_rate_id = normalize_foreign_key_id(data['tax_rate_id'])
-            if tax_rate_id is not None:
-                line.tax_rate = get_object_or_404(TaxRate, pk=tax_rate_id)
-        if 'is_selected' in data:
-            line.is_selected = data['is_selected']
-        if 'unit_id' in data or 'unit' in data:
-            unit_value = data.get('unit_id', data.get('unit'))
-            line.unit_id = normalize_foreign_key_id(unit_value)
-        if 'discount' in data:
-            discount_value = data['discount']
-            if discount_value not in (None, ''):
+    try:
+        with transaction.atomic():
+            # Lock the row for the duration of the read-modify-write so that
+            # overlapping edits of the same line are serialized instead of
+            # racing on a full-row save() (last-writer-wins over stale fields).
+            line = get_object_or_404(
+                SalesDocumentLine.objects.select_for_update(),
+                pk=line_id, document=document
+            )
+
+            provided_short_text_1 = 'short_text_1' in data
+            provided_short_text_2 = 'short_text_2' in data
+            provided_long_text = 'long_text' in data
+            provided_description = 'description' in data
+            provided_tax_rate = 'tax_rate_id' in data
+            provided_unit_price = 'unit_price_net' in data
+
+            new_item = None
+            item_changed = False
+
+            # recognized_keys tracks which submitted keys this endpoint understood
+            # (regardless of whether they changed anything); touched_fields tracks
+            # which model fields actually need to be written, so save() only
+            # overwrites the fields that were part of this request.
+            recognized_keys = set()
+            touched_fields = set()
+
+            if 'item_id' in data:
+                recognized_keys.add('item_id')
+                item_id = normalize_foreign_key_id(data['item_id'])
+                if item_id is not None:
+                    try:
+                        new_item = Item.objects.get(pk=item_id)
+                    except Item.DoesNotExist:
+                        raise ValueError(f'Ungültiger Artikel: Kein Artikel mit ID {item_id} gefunden.')
+                    item_changed = line.item_id != new_item.pk
+                    line.item = new_item
+                else:
+                    item_changed = line.item_id is not None
+                    line.item = None
+                touched_fields.add('item')
+            if 'quantity' in data:
+                recognized_keys.add('quantity')
                 try:
-                    line.discount = Decimal(str(discount_value))
-                except (ValueError, TypeError):
-                    line.discount = Decimal('0.00')
-            else:
-                line.discount = Decimal('0.00')
-        if 'kostenart1_id' in data:
-            line.kostenart1_id = normalize_foreign_key_id(data['kostenart1_id'])
-        if 'kostenart2_id' in data:
-            line.kostenart2_id = normalize_foreign_key_id(data['kostenart2_id'])
+                    line.quantity = normalize_decimal_input(data['quantity'])
+                except (ValueError, TypeError) as e:
+                    raise ValueError(f'Ungültige Menge: {e}')
+                touched_fields.add('quantity')
+            if 'unit_price_net' in data:
+                recognized_keys.add('unit_price_net')
+                try:
+                    line.unit_price_net = normalize_decimal_input(data['unit_price_net'])
+                except (ValueError, TypeError) as e:
+                    raise ValueError(f'Ungültiger Netto-Stückpreis: {e}')
+                touched_fields.add('unit_price_net')
+            if 'short_text_1' in data:
+                recognized_keys.add('short_text_1')
+                line.short_text_1 = data['short_text_1']
+                touched_fields.add('short_text_1')
+            if 'short_text_2' in data:
+                recognized_keys.add('short_text_2')
+                line.short_text_2 = data['short_text_2']
+                touched_fields.add('short_text_2')
+            if 'long_text' in data:
+                recognized_keys.add('long_text')
+                # Log the update for debugging Issue #377
+                logger.debug(f"Updating long_text for line {line_id}: old_value='{line.long_text}', new_value='{data['long_text']}'")
+                # long_text is rendered with the `|safe` filter in PDF templates, so it must be
+                # bleach-sanitized. short_text_1/2 and description are always auto-escaped by
+                # Django templates and stored as plain text, so no sanitization is applied there.
+                line.long_text = sanitize_html(data['long_text'])
+                touched_fields.add('long_text')
+            if 'description' in data:
+                recognized_keys.add('description')
+                line.description = data['description']
+                touched_fields.add('description')
+            if 'tax_rate_id' in data:
+                recognized_keys.add('tax_rate_id')
+                tax_rate_id = normalize_foreign_key_id(data['tax_rate_id'])
+                if tax_rate_id is not None:
+                    try:
+                        line.tax_rate = TaxRate.objects.get(pk=tax_rate_id)
+                    except TaxRate.DoesNotExist:
+                        raise ValueError(f'Ungültiger Steuersatz: Kein Steuersatz mit ID {tax_rate_id} gefunden.')
+                    touched_fields.add('tax_rate')
+            if 'is_selected' in data:
+                recognized_keys.add('is_selected')
+                line.is_selected = data['is_selected']
+                touched_fields.add('is_selected')
+            if 'unit_id' in data or 'unit' in data:
+                recognized_keys.update({'unit_id', 'unit'} & data.keys())
+                unit_value = data.get('unit_id', data.get('unit'))
+                line.unit_id = normalize_foreign_key_id(unit_value)
+                touched_fields.add('unit')
+            if 'discount' in data:
+                recognized_keys.add('discount')
+                discount_value = data['discount']
+                try:
+                    line.discount = (
+                        normalize_decimal_input(discount_value)
+                        if discount_value not in (None, '') else Decimal('0.00')
+                    )
+                except (ValueError, TypeError) as e:
+                    raise ValueError(f'Ungültiger Rabatt: {e}')
+                touched_fields.add('discount')
+            if 'kostenart1_id' in data:
+                recognized_keys.add('kostenart1_id')
+                line.kostenart1_id = normalize_foreign_key_id(data['kostenart1_id'])
+                touched_fields.add('kostenart1')
+            if 'kostenart2_id' in data:
+                recognized_keys.add('kostenart2_id')
+                line.kostenart2_id = normalize_foreign_key_id(data['kostenart2_id'])
+                touched_fields.add('kostenart2')
 
-        if item_changed and new_item:
-            if not provided_short_text_1:
-                line.short_text_1 = new_item.short_text_1 or ''
-            if not provided_short_text_2:
-                line.short_text_2 = new_item.short_text_2 or ''
-            if not provided_long_text:
-                line.long_text = sanitize_html(new_item.long_text) if new_item.long_text else ''
-            if not provided_description:
-                description_parts = [
-                    line.short_text_1,
-                    line.short_text_2,
-                    strip_tags(line.long_text) if line.long_text else '',
-                ]
-                line.description = '\n'.join([p for p in description_parts if p])
-            if not provided_unit_price:
-                line.unit_price_net = new_item.net_price
-            if not provided_tax_rate:
-                line.tax_rate = TaxDeterminationService.determine_tax_rate(
-                    customer=document.customer,
-                    item_tax_rate=new_item.tax_rate
-                )
-            if 'is_discountable' not in data:
-                line.is_discountable = new_item.is_discountable
-            if 'kostenart1_id' not in data and new_item.cost_type_1:
-                line.kostenart1 = new_item.cost_type_1
-            if 'kostenart2_id' not in data:
-                line.kostenart2 = new_item.cost_type_2
-        
-        # Recalculate line totals using the service before saving
-        line_net, line_tax, line_gross = DocumentCalculationService.calculate_line_totals(line)
-        line.line_net = line_net
-        line.line_tax = line_tax
-        line.line_gross = line_gross
-        
-        # Save all line changes in a single database write
-        line.save()
-        
-        # Recalculate and persist document totals
-        DocumentCalculationService.recalculate(document, persist=True)
-        
-        # Return updated line data
-        return JsonResponse({
-            'success': True,
-            'line': {
-                'id': line.pk,
-                'item_id': line.item.pk if line.item else None,
-                'short_text_1': line.short_text_1,
-                'short_text_2': line.short_text_2,
-                'long_text': line.long_text,
-                'quantity': str(line.quantity),
-                'unit_id': line.unit.pk if line.unit else None,
-                'unit_symbol': line.unit.symbol if line.unit else '',
-                'unit_price_net': str(line.unit_price_net),
-                'discount': str(line.discount),
-                'tax_rate_id': line.tax_rate.pk if line.tax_rate else None,
-                'description': line.description,
-                'line_net': str(line.line_net),
-                'line_tax': str(line.line_tax),
-                'line_gross': str(line.line_gross),
-                'kostenart1_id': line.kostenart1.pk if line.kostenart1 else None,
-                'kostenart2_id': line.kostenart2.pk if line.kostenart2 else None,
-            },
-            'totals': {
-                'total_net': str(document.total_net),
-                'total_tax': str(document.total_tax),
-                'total_gross': str(document.total_gross),
-            }
-        })
+            if not recognized_keys:
+                raise ValueError('Keine bekannten Felder in der Anfrage gefunden.')
+
+            if item_changed and new_item:
+                if not provided_short_text_1:
+                    line.short_text_1 = new_item.short_text_1 or ''
+                    touched_fields.add('short_text_1')
+                if not provided_short_text_2:
+                    line.short_text_2 = new_item.short_text_2 or ''
+                    touched_fields.add('short_text_2')
+                if not provided_long_text:
+                    line.long_text = sanitize_html(new_item.long_text) if new_item.long_text else ''
+                    touched_fields.add('long_text')
+                if not provided_description:
+                    description_parts = [
+                        line.short_text_1,
+                        line.short_text_2,
+                        strip_tags(line.long_text) if line.long_text else '',
+                    ]
+                    line.description = '\n'.join([p for p in description_parts if p])
+                    touched_fields.add('description')
+                if not provided_unit_price:
+                    line.unit_price_net = new_item.net_price
+                    touched_fields.add('unit_price_net')
+                if not provided_tax_rate:
+                    line.tax_rate = TaxDeterminationService.determine_tax_rate(
+                        customer=document.customer,
+                        item_tax_rate=new_item.tax_rate
+                    )
+                    touched_fields.add('tax_rate')
+                if 'is_discountable' not in data:
+                    line.is_discountable = new_item.is_discountable
+                    touched_fields.add('is_discountable')
+                if 'kostenart1_id' not in data and new_item.cost_type_1:
+                    line.kostenart1 = new_item.cost_type_1
+                    touched_fields.add('kostenart1')
+                if 'kostenart2_id' not in data:
+                    line.kostenart2 = new_item.cost_type_2
+                    touched_fields.add('kostenart2')
+
+            # Recalculate line totals using the service before saving
+            line_net, line_tax, line_gross = DocumentCalculationService.calculate_line_totals(line)
+            line.line_net = line_net
+            line.line_tax = line_tax
+            line.line_gross = line_gross
+            touched_fields.update({'line_net', 'line_tax', 'line_gross'})
+
+            # Only write the fields this request actually touched, so an overlapping
+            # save of a different field on the same line can never clobber it.
+            line.save(update_fields=sorted(touched_fields))
+
+            # Recalculate and persist document totals
+            DocumentCalculationService.recalculate(document, persist=True)
+    except Http404:
+        raise
+    except ValueError as e:
+        return JsonResponse({'success': False, 'error': str(e)}, status=400)
     except Exception as e:
-        logger.exception(f"Error updating line {line_id} in document {pk}: {str(e)}")
-        return JsonResponse({'error': str(e)}, status=500)
+        logger.exception(f"Error updating line {line_id} in document {pk}: {e}")
+        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+
+    # Return updated line data
+    return JsonResponse({
+        'success': True,
+        'line': {
+            'id': line.pk,
+            'item_id': line.item.pk if line.item else None,
+            'short_text_1': line.short_text_1,
+            'short_text_2': line.short_text_2,
+            'long_text': line.long_text,
+            'quantity': str(line.quantity),
+            'unit_id': line.unit.pk if line.unit else None,
+            'unit_symbol': line.unit.symbol if line.unit else '',
+            'unit_price_net': str(line.unit_price_net),
+            'discount': str(line.discount),
+            'tax_rate_id': line.tax_rate.pk if line.tax_rate else None,
+            'description': line.description,
+            'line_net': str(line.line_net),
+            'line_tax': str(line.line_tax),
+            'line_gross': str(line.line_gross),
+            'kostenart1_id': line.kostenart1.pk if line.kostenart1 else None,
+            'kostenart2_id': line.kostenart2.pk if line.kostenart2 else None,
+        },
+        'totals': {
+            'total_net': str(document.total_net),
+            'total_tax': str(document.total_tax),
+            'total_gross': str(document.total_gross),
+        }
+    })
 
 
 @login_required

--- a/auftragsverwaltung/views.py
+++ b/auftragsverwaltung/views.py
@@ -1170,7 +1170,7 @@ def ajax_update_line(request, doc_key, pk, line_id):
         return JsonResponse({'success': False, 'error': str(e)}, status=400)
     except Exception as e:
         logger.exception(f"Error updating line {line_id} in document {pk}: {e}")
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse({'success': False, 'error': 'An internal error occurred.'}, status=500)
 
     # Return updated line data
     return JsonResponse({

--- a/auftragsverwaltung/views.py
+++ b/auftragsverwaltung/views.py
@@ -913,7 +913,7 @@ def ajax_add_line(request, doc_key, pk):
         raise
     except Exception as e:
         logger.exception(f"Error adding line to document {pk}: {e}")
-        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+        return JsonResponse({'success': False, 'error': 'An internal error has occurred.'}, status=500)
 
     # Return line data
     return JsonResponse({

--- a/auftragsverwaltung/views.py
+++ b/auftragsverwaltung/views.py
@@ -863,7 +863,8 @@ def ajax_add_line(request, doc_key, pk):
             else:
                 unit_price_net_decimal = normalize_decimal_input(unit_price_net)
         except (ValueError, TypeError) as e:
-            return JsonResponse({'success': False, 'error': f'Ungültiger Netto-Stückpreis: {e}'}, status=400)
+            logger.warning("Ungültiger Netto-Stückpreis in add/update line request.", exc_info=True)
+            return JsonResponse({'success': False, 'error': 'Ungültiger Netto-Stückpreis.'}, status=400)
 
         # Get unit and discount if provided
         unit_id = data.get('unit_id')
@@ -874,7 +875,8 @@ def ajax_add_line(request, doc_key, pk):
                 normalize_decimal_input(discount) if discount not in (None, '') else Decimal('0.00')
             )
         except (ValueError, TypeError) as e:
-            return JsonResponse({'success': False, 'error': f'Ungültiger Rabatt: {e}'}, status=400)
+            logger.warning("Ungültiger Rabatt in add/update line request.", exc_info=True)
+            return JsonResponse({'success': False, 'error': 'Ungültiger Rabatt.'}, status=400)
 
         with transaction.atomic():
             # Get next position number

--- a/auftragsverwaltung/views.py
+++ b/auftragsverwaltung/views.py
@@ -1167,10 +1167,11 @@ def ajax_update_line(request, doc_key, pk, line_id):
     except Http404:
         raise
     except ValueError as e:
-        return JsonResponse({'success': False, 'error': str(e)}, status=400)
+        logger.warning(f"Validation error updating line {line_id} in document {pk}: {e}")
+        return JsonResponse({'success': False, 'error': 'Invalid input.'}, status=400)
     except Exception as e:
         logger.exception(f"Error updating line {line_id} in document {pk}: {e}")
-        return JsonResponse({'success': False, 'error': 'An internal error occurred.'}, status=500)
+        return JsonResponse({'success': False, 'error': 'An internal error has occurred.'}, status=500)
 
     # Return updated line data
     return JsonResponse({


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #935.

Model: Sonnet
Job: #113

---

## Zusammenfassung

Härtet die beiden Line-Save-Endpunkte `ajax_add_line` und `ajax_update_line` (`auftragsverwaltung/views.py`) gegen den in Epic #721 beschriebenen stillen Datenverlust: ungültige/deutsche Zahleneingaben, ungültige `tax_rate_id`/`item_id`, kaputte JSON-Bodies und überlappende Saves derselben Position führen nicht mehr zu verlorenen Feldern, `500`-Fehlern oder einem irreführenden `success: True` bei No-Ops.

## Änderungen

- `quantity`, `unit_price_net` und `discount` werden in beiden Endpunkten über `normalize_decimal_input()` geparst statt über rohes `Decimal(...)`. Ungültige Eingaben liefern jetzt `HTTP 400` mit feldbezogener Fehlermeldung (`Ungültige Menge`, `Ungültiger Netto-Stückpreis`, `Ungültiger Rabatt`) statt eines `500`.
- `get_object_or_404(TaxRate/Item)` in beiden Endpunkten durch explizite `.get()`-Lookups ersetzt, die bei ungültiger ID einen `ValueError` mit klarer Meldung auslösen (`400`) statt eines von der pauschalen `except Exception` verschluckten `Http404`.
- `ajax_update_line` kapselt Lesen, Verändern und Speichern der Zeile jetzt in `transaction.atomic()` mit `SalesDocumentLine.objects.select_for_update()`. `line.save()` erhält ein explizites `update_fields`, das nur die vom Request tatsächlich berührten Felder (plus die stets neu berechneten `line_net`/`line_tax`/`line_gross`) enthält – ein Full-Row-Save ohne `update_fields` gibt es nicht mehr.
- Neue Unterscheidung zwischen "vom Request erkannte Schlüssel" und "tatsächlich geänderte Modellfelder": Ein leerer JSON-Body, ein kaputter/abgeschnittener JSON-Body bei `Content-Type: application/json` oder ein Payload, der ausschließlich unbekannte Schlüssel enthält, liefert jetzt `HTTP 400` mit `success: False` statt eines stillen No-Ops mit `success: True`.
- `except Exception` in beiden Views auf `except Http404: raise` (echter 404 statt verschluckter 500) und `except ValueError` (400) reduziert; ein verbleibendes `except Exception` fängt nur noch tatsächlich unerwartete Fehler als `500` ab.
- Entfernt eine tote, folgenlose `price_value = float(...)`-Berechnung in `ajax_add_line`, die nur zur Validierung gedacht war, aber nirgends ausgewertet wurde.
- Kurzer Code-Kommentar dokumentiert die bewusste Sanitization-Regel: `long_text` wird per `bleach` sanitisiert, weil es in PDF-Templates mit `|safe` gerendert wird; `short_text_1`/`short_text_2`/`description` bleiben unsanitisiert, weil sie ausschließlich als Klartext über Djangos Auto-Escaping gerendert werden.

## Warum / Entscheidungen

- **Ganzheitliche Request-Atomarität statt Teil-Speicherung bei ungültiger FK**: Bei ungültiger `tax_rate_id`/`item_id` wird der komplette Request mit `400` abgelehnt, auch wenn andere Felder im selben Payload gültig wären – nicht ein "gültige Felder trotzdem speichern, nur FK-Feld verwerfen"-Ansatz, weil das eine unklare Teil-Erfolgs-Semantik erzeugen würde (Client müsste raten, welche Felder übernommen wurden). Der Client bekommt stattdessen eine eindeutige Fehlermeldung und kann denselben Payload mit korrigierter ID erneut senden, ohne dass zwischenzeitlich ein inkonsistenter Zustand entsteht.
- **`select_for_update()` statt optimistischem Locking (z. B. Versionsfeld)**: Ein zusätzliches `version`-Feld hätte eine Migration, Frontend-Änderungen zum Mitschicken der Version und Konfliktbehandlung im UI erfordert – deutlich größerer Scope als die geforderte Sofortmaßnahme. `select_for_update()` innerhalb von `transaction.atomic()` serialisiert überlappende Saves auf Datenbankebene ohne Schemaänderung; auf SQLite (Test/Dev) ist der Aufruf ein dokumentiertes No-Op (kein Fehler), auf PostgreSQL (Prod) greift die echte Row-Lock-Semantik.
- **`update_fields` statt vollständigem Row-Replace**: Der bisherige `line.save()` ohne `update_fields` hat bei jedem Aufruf die komplette Zeile inklusive nicht übermittelter, im Speicher veralteter Felder zurückgeschrieben. Jetzt wird nur geschrieben, was der Request tatsächlich verändert hat (plus die immer neu berechneten Summenfelder) – das behebt das Last-Writer-Wins-Problem direkt an der Wurzel, ohne dass ein Konflikt aktiv erkannt/abgelehnt werden muss.
- **Nicht bleach für `short_text_1`/`short_text_2`/`description`**: Diese Felder werden nirgends mit `|safe` gerendert, sondern durchgängig von Djangos Template-Auto-Escaping erfasst. Zusätzliches Sanitizing hätte hier keinen Sicherheitsgewinn, würde aber legitime Sonderzeichen unnötig entfernen; die bestehende Inkonsistenz zu `long_text` ist damit weiterhin vorhanden, aber bewusst und dokumentiert, nicht versehentlich.
- **Kein generisches Response-Envelope-Refactoring**: Die Fehlerantwort wurde um `success: False` ergänzt (vorher nur `error`), aber die sonstige Response-Struktur (`line`, `totals`) bleibt unverändert, um den bestehenden Frontend-Code und alle bestehenden Tests nicht unnötig zu brechen – Sub 2/3 des Epics adressiert das Frontend-Redesign separat.
- **Kein Fix für die `position_no`-Vergabe in `ajax_add_line`**: Die `max(position_no) + 1`-Ermittlung bleibt ungesperrt, da eine Race Condition bei parallelem Hinzufügen neuer Positionen ein anderes Problem ist als der in dieser Sub-Aufgabe beschriebene Feldverlust beim Update derselben Zeile; eine Lösung dafür (z. B. `select_for_update()` auf der Dokument-Zeilen-Aggregation oder ein DB-Sequence-Ansatz) würde den Scope dieser Sofortmaßnahme sprengen.

## Test-Hinweise

- Neue Datei `auftragsverwaltung/test_line_save_hardening.py` (17 Tests) deckt gezielt ab:
  - Überlappendes Save derselben Zeile überschreibt ein zwischenzeitlich von einer "anderen Anfrage" (simuliert über ein `pre_save`-Signal, das direkt in der DB schreibt) geändertes Feld nicht mehr.
  - Deutsches Dezimalformat (`"2,500"`, `"49,90"`) für `quantity`/`unit_price_net` in Add und Update.
  - Ungültige/leere `quantity`, `unit_price_net`, `discount` in Add und Update liefern `400` mit feldbezogener Meldung statt `500`, andere Felder bleiben unverändert.
  - Kaputter/abgeschnittener JSON-Body bei `Content-Type: application/json`, leeres `{}` sowie ein Payload mit ausschließlich unbekannten Schlüsseln liefern `400` mit `success: False` statt stillem `success: True`.
  - Ungültige `tax_rate_id`/`item_id` in Add und Update liefern `400`; im Update-Fall bleibt die Zeile unverändert und ein erneuter Request ohne die ungültige ID greift danach erfolgreich.
- Bestehende Suiten `test_ajax_line_update.py`, `test_multiple_position_save.py`, `test_issue_377_langtext.py`, `test_unit_persistence.py`, `test_unit_integration.py`, `test_decimal_parsing.py` laufen unverändert grün (48 Tests).
- Vollständiger Lauf `python manage.py test auftragsverwaltung --settings=test_settings`: 481 Tests, dieselben 15 bereits vor dieser Änderung fehlschlagenden/fehlerhaften Tests (u. a. `test_document_create`, `test_contract_views`, `test_number_range`, `test_timeentry`) sind unverändert vorhanden und nicht durch diese Änderung verursacht (per `git stash` gegen den unveränderten Branch verifiziert); keine neuen Fehlschläge.
- `python manage.py makemigrations --check --settings=test_settings`: keine Änderungen erkannt (reine Verhaltensänderung, kein Modell betroffen).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core order line persistence and concurrency behavior on heavily used AJAX endpoints; changes are well-tested but incorrect client assumptions about partial success on validation failure could surface.
> 
> **Overview**
> Hardens **`ajax_add_line`** and **`ajax_update_line`** so document line saves no longer lose data or return misleading success responses (Issue #721).
> 
> **`ajax_update_line`** now runs inside **`transaction.atomic()`** with **`select_for_update()`** and persists only request-touched columns via **`save(update_fields=...)`**, avoiding full-row overwrites when two edits overlap. **`ajax_add_line`** wraps create + total recalculation in a transaction.
> 
> Both endpoints parse **`quantity`**, **`unit_price_net`**, and **`discount`** through **`normalize_decimal_input()`** (German decimals supported); bad values return **HTTP 400** with **`success: false`** instead of **500**. Invalid or missing JSON, empty payloads, and unknown-only keys are rejected with **400** (JSON bodies with **`application/json`** no longer fall back silently). Invalid **`tax_rate_id`** / **`item_id`** use explicit lookups and **400** responses; failed validation rolls back the whole update so partial writes do not apply.
> 
> Adds **`test_line_save_hardening.py`** (17 regression tests) for concurrency, decimals, payloads, and FK errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f3bdbd517365ef53d841c71a8ab848d228076e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->