### PR TITLE
[#721 Sub 2/4] Frontend Save-Schicht neu: ein atomarer, serialisierter Save pro Position

### DIFF
--- a/auftragsverwaltung/test_unit_persistence.py
+++ b/auftragsverwaltung/test_unit_persistence.py
@@ -326,7 +326,7 @@ class UnitPersistenceTestCase(TestCase):
         self.assertIn(self.unit_lfm.symbol, units)
 
     def test_unit_select_has_name_attribute(self):
-        """Detail view should render unit select with name for HTMX payloads"""
+        """Detail view should render unit select with name for the line-save payload"""
         self.line.unit = self.unit_stk
         self.line.save()
 
@@ -338,5 +338,5 @@ class UnitPersistenceTestCase(TestCase):
 
         self.assertEqual(response.status_code, 200)
         content = response.content.decode('utf-8')
-        self.assertIn('class="form-select form-select-sm line-unit"', content)
+        self.assertIn('class="form-select form-select-sm line-unit line-autosave-field"', content)
         self.assertIn('name="unit_id"', content)

--- a/templates/auftragsverwaltung/documents/detail.html
+++ b/templates/auftragsverwaltung/documents/detail.html
@@ -515,35 +515,24 @@ Neues {{ document_type.name }}
                                         <!-- Row 1: short_text_1, quantity, unit, unit_price_net, discount -->
                                         <div class="row g-1 mb-1">
                                             <div class="col-md-4">
-                                                <input type="text" 
-                                                       class="form-control form-control-sm line-short-text-1" 
+                                                <input type="text"
+                                                       class="form-control form-control-sm line-short-text-1 line-autosave-field"
                                                        data-line-id="{{ line.pk }}"
-                                                       value="{{ line.short_text_1 }}" 
-                                                       placeholder="Kurztext"
-                                                       hx-post="{% url 'auftragsverwaltung:ajax_update_line' doc_key document.pk line.pk %}"
-                                                       hx-trigger="change, keyup changed delay:500ms"
-                                                       hx-vals='js:{"short_text_1": this.value}'
-                                                       hx-swap="none">
+                                                       value="{{ line.short_text_1 }}"
+                                                       placeholder="Kurztext">
                                                 <div id="suggestions-{{ line.pk }}" class="article-suggestions" style="display: none;"></div>
                                             </div>
                                             <div class="col-md-2">
-                                                <input type="number" 
-                                                       class="form-control form-control-sm line-quantity" 
-                                                       value="{{ line.quantity|unlocalize }}" 
-                                                       step="0.01" 
-                                                       min="0" 
-                                                       placeholder="Menge"
-                                                       hx-post="{% url 'auftragsverwaltung:ajax_update_line' doc_key document.pk line.pk %}"
-                                                       hx-trigger="change"
-                                                       hx-vals='js:{"quantity": parseFloat(this.value) || 0}'
-                                                       hx-swap="none">
+                                                <input type="number"
+                                                       class="form-control form-control-sm line-quantity line-autosave-field"
+                                                       value="{{ line.quantity|unlocalize }}"
+                                                       step="0.01"
+                                                       min="0"
+                                                       placeholder="Menge">
                                             </div>
                                             <div class="col-md-2">
-                                                <select class="form-select form-select-sm line-unit"
-                                                        name="unit_id"
-                                                        hx-post="{% url 'auftragsverwaltung:ajax_update_line' doc_key document.pk line.pk %}"
-                                                        hx-trigger="change"
-                                                        hx-swap="none">
+                                                <select class="form-select form-select-sm line-unit line-autosave-field"
+                                                        name="unit_id">
                                                     <option value="">--</option>
                                                     {% for unit in units %}
                                                     <option value="{{ unit.pk }}" {% if line.unit and line.unit.pk == unit.pk %}selected{% endif %}>
@@ -553,29 +542,21 @@ Neues {{ document_type.name }}
                                                 </select>
                                             </div>
                                             <div class="col-md-2">
-                                                <input type="number" 
-                                                       class="form-control form-control-sm line-unit-price" 
-                                                       value="{{ line.unit_price_net|unlocalize }}" 
-                                                       step="0.01" 
-                                                       min="0" 
-                                                       placeholder="€"
-                                                       hx-post="{% url 'auftragsverwaltung:ajax_update_line' doc_key document.pk line.pk %}"
-                                                       hx-trigger="change"
-                                                       hx-vals='js:{"unit_price_net": parseFloat(this.value) || 0}'
-                                                       hx-swap="none">
+                                                <input type="number"
+                                                       class="form-control form-control-sm line-unit-price line-autosave-field"
+                                                       value="{{ line.unit_price_net|unlocalize }}"
+                                                       step="0.01"
+                                                       min="0"
+                                                       placeholder="€">
                                             </div>
                                             <div class="col-md-2">
-                                                <input type="number" 
-                                                       class="form-control form-control-sm line-discount" 
-                                                       value="{{ line.discount|unlocalize }}" 
-                                                       step="0.01" 
-                                                       min="0" 
-                                                       max="100" 
-                                                       placeholder="%"
-                                                       hx-post="{% url 'auftragsverwaltung:ajax_update_line' doc_key document.pk line.pk %}"
-                                                       hx-trigger="change"
-                                                       hx-vals='js:{"discount": parseFloat(this.value) || 0}'
-                                                       hx-swap="none">
+                                                <input type="number"
+                                                       class="form-control form-control-sm line-discount line-autosave-field"
+                                                       value="{{ line.discount|unlocalize }}"
+                                                       step="0.01"
+                                                       min="0"
+                                                       max="100"
+                                                       placeholder="%">
                                             </div>
                                         </div>
                                         <!-- Row 2: long_text preview + edit button -->
@@ -609,11 +590,7 @@ Neues {{ document_type.name }}
                                                            style="background-color: var(--bs-secondary-bg);">
                                                 </div>
                                                 <div>
-                                                    <select class="form-select form-select-sm line-tax-rate"
-                                                            hx-post="{% url 'auftragsverwaltung:ajax_update_line' doc_key document.pk line.pk %}"
-                                                            hx-trigger="change"
-                                                            hx-vals='js:{"tax_rate_id": parseInt(this.value) || null}'
-                                                            hx-swap="none">
+                                                    <select class="form-select form-select-sm line-tax-rate line-autosave-field">
                                                         {% for tax_rate in tax_rates %}
                                                         <option value="{{ tax_rate.pk }}" {% if line.tax_rate.pk == tax_rate.pk %}selected{% endif %}>
                                                             {{ tax_rate.code }} ({{ tax_rate.rate }}%)
@@ -927,63 +904,97 @@ document.addEventListener('DOMContentLoaded', function() {
     let isInitialLoad = true;
     const unsavedIndicator = document.getElementById('unsavedIndicator');
     
+    {% if document.pk %}
     // ============================================================================
-    // HTMX Event Handlers for Auto-Save
+    // Positionen: ein atomarer, serialisierter Save pro Zeile (Issue #721)
+    //
+    // Ersetzt die frühere Doppelspur aus HTMX-Autosave + manuellem
+    // updateLineField()-fetch (die auf denselben Feldern konkurrierende POSTs
+    // auslöste). Alle Feldänderungen einer Zeile werden gesammelt und als ein
+    // Request gesendet; ein zweiter Save derselben Zeile wartet auf den ersten,
+    // statt parallel zu laufen.
     // ============================================================================
-    
-    // Listen for HTMX responses and update totals
-    document.body.addEventListener('htmx:afterRequest', function(event) {
-        // Only handle responses from our line update endpoints
-        if (event.detail.pathInfo.requestPath.includes('/lines/') && event.detail.pathInfo.requestPath.includes('/update/')) {
-            const xhr = event.detail.xhr;
-            if (xhr.status === 200) {
-                try {
-                    const response = JSON.parse(xhr.responseText);
-                    if (response.success) {
-                        // Update line totals
-                        if (response.line) {
-                            const lineId = response.line.id;
-                            const lineItem = document.querySelector(`.line-item[data-line-id="${lineId}"]`);
-                            if (lineItem) {
-                                const lineNetEl = lineItem.querySelector('.line-net');
-                                if (lineNetEl && response.line.line_net) {
-                                    lineNetEl.value = parseFloat(response.line.line_net).toFixed(2) + ' €';
-                                }
-                                
-                                // Update unit dropdown selection
-                                const unitSelect = lineItem.querySelector('.line-unit');
-                                if (unitSelect && 'unit_id' in response.line) {
-                                    unitSelect.value = response.line.unit_id || '';
-                                }
-                            }
-                        }
-                        
-                        // Update document totals
-                        if (response.totals) {
-                            const totalNetEl = document.getElementById('totalNet');
-                            const totalGrossEl = document.getElementById('totalGross');
-                            
-                            if (totalNetEl && response.totals.total_net) {
-                                totalNetEl.textContent = parseFloat(response.totals.total_net).toFixed(2) + ' €';
-                            }
-                            if (totalGrossEl && response.totals.total_gross) {
-                                totalGrossEl.textContent = parseFloat(response.totals.total_gross).toFixed(2) + ' €';
-                            }
-                        }
-                    }
-                } catch (e) {
-                    console.error('Error parsing HTMX response:', e);
-                }
+    const lineSaveState = new Map(); // lineId -> { pending, timer, inFlight }
+    const LINE_SAVE_DEBOUNCE_MS = 500;
+
+    function getLineSaveEntry(lineId) {
+        let entry = lineSaveState.get(lineId);
+        if (!entry) {
+            entry = { pending: {}, timer: null, inFlight: null };
+            lineSaveState.set(lineId, entry);
+        }
+        return entry;
+    }
+
+    function hasPendingLineSaves() {
+        for (const entry of lineSaveState.values()) {
+            if (entry.timer || Object.keys(entry.pending).length || entry.inFlight) {
+                return true;
             }
         }
-    });
-    
-    // Silent error handling for HTMX - don't show alerts
-    document.body.addEventListener('htmx:responseError', function(event) {
-        console.error('HTMX Error:', event.detail);
-        // No alert - silent fail as per requirements
-    });
-    
+        return false;
+    }
+
+    // Sends the currently pending fields of one line as a single request. If a
+    // save for this line is already in flight, the new one is chained after it
+    // so requests for the same line are never sent concurrently.
+    function flushLineSave(lineId) {
+        const entry = getLineSaveEntry(lineId);
+        if (entry.timer) {
+            clearTimeout(entry.timer);
+            entry.timer = null;
+        }
+        if (!Object.keys(entry.pending).length) {
+            return entry.inFlight || Promise.resolve();
+        }
+
+        const payload = entry.pending;
+        entry.pending = {};
+
+        entry.inFlight = (entry.inFlight || Promise.resolve())
+            .then(function() { return updateLineField(lineId, payload); })
+            .finally(function() {
+                if (!Object.keys(entry.pending).length) {
+                    entry.inFlight = null;
+                }
+            });
+
+        return entry.inFlight;
+    }
+
+    // Bundles a field change into the line's pending payload and (re-)starts the
+    // debounce timer; rapid successive edits of different fields on the same
+    // line collapse into one request instead of one POST per field.
+    function scheduleLineSave(lineId, fieldData) {
+        const entry = getLineSaveEntry(lineId);
+        Object.assign(entry.pending, fieldData);
+        if (entry.timer) {
+            clearTimeout(entry.timer);
+        }
+        entry.timer = setTimeout(function() { flushLineSave(lineId); }, LINE_SAVE_DEBOUNCE_MS);
+    }
+
+    // For discrete actions (select change, modal "Speichern") that should commit
+    // immediately instead of waiting out the debounce.
+    function saveLineFieldsNow(lineId, fieldData) {
+        scheduleLineSave(lineId, fieldData);
+        return flushLineSave(lineId);
+    }
+
+    // Flushes every line with unsaved edits right away; must be awaited before
+    // Add/Delete/Artikel/Submit so a still-pending debounce can't be dropped by
+    // the ensuing reload/navigation.
+    function flushAllLineSaves() {
+        const flushes = [];
+        lineSaveState.forEach(function(entry, lineId) {
+            if (entry.timer || Object.keys(entry.pending).length || entry.inFlight) {
+                flushes.push(flushLineSave(lineId));
+            }
+        });
+        return Promise.all(flushes);
+    }
+    {% endif %}
+
     // ============================================================================
     // Quill Editors for Header and Footer Text
     // ============================================================================
@@ -1056,8 +1067,8 @@ document.addEventListener('DOMContentLoaded', function() {
     // Mark form as dirty on any change
     // ============================================================================
     
-    // Mark form as dirty on any change (excluding HTMX auto-saved fields)
-    document.querySelectorAll('input:not([hx-post]), textarea:not([hx-post]), select:not([hx-post])').forEach(el => {
+    // Mark form as dirty on any change (excluding line fields, which autosave on their own)
+    document.querySelectorAll('input:not(.line-autosave-field), textarea:not(.line-autosave-field), select:not(.line-autosave-field)').forEach(el => {
         el.addEventListener('change', function(event) {
             // Only set dirty on user changes (after initial load)
             if (!isInitialLoad) {
@@ -1078,12 +1089,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 form.reportValidity();
                 return;
             }
-            // Reset isDirty flag before submission to prevent warning
-            isDirty = false;
-            if (unsavedIndicator) {
-                unsavedIndicator.classList.remove('show');
-            }
-            form.submit();
+            saveButton.disabled = true;
+            // Flush any still-pending/debounced line edits before navigating away,
+            // otherwise a save that hasn't fired yet would be lost on submit.
+            ({% if document.pk %}flushAllLineSaves(){% else %}Promise.resolve(){% endif %}).finally(function() {
+                // Reset isDirty flag before submission to prevent warning
+                isDirty = false;
+                if (unsavedIndicator) {
+                    unsavedIndicator.classList.remove('show');
+                }
+                form.submit();
+            });
         });
     }
     
@@ -1166,7 +1182,7 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Unsaved changes warning
     window.addEventListener('beforeunload', function(e) {
-        if (isDirty) {
+        if (isDirty || ({% if document.pk %}hasPendingLineSaves(){% else %}false{% endif %})) {
             e.preventDefault();
             e.returnValue = '';
             return '';
@@ -1244,38 +1260,42 @@ document.addEventListener('DOMContentLoaded', function() {
             alert('Kein Steuersatz verfügbar');
             return;
         }
-        
-        fetch('{% url "auftragsverwaltung:ajax_add_line" doc_key document.pk %}', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': '{{ csrf_token }}'
-            },
-            body: JSON.stringify({
-                short_text_1: 'Neue Position',
-                short_text_2: '',
-                long_text: '',
-                quantity: 1.0,
-                unit_price_net: 0.00,
-                tax_rate_id: defaultTaxRateId,
-                line_type: 'NORMAL'
+
+        // Flush pending edits on other lines first, so the reload below can't
+        // race ahead of a still-debounced save and drop it.
+        flushAllLineSaves().finally(function() {
+            fetch('{% url "auftragsverwaltung:ajax_add_line" doc_key document.pk %}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': '{{ csrf_token }}'
+                },
+                body: JSON.stringify({
+                    short_text_1: 'Neue Position',
+                    short_text_2: '',
+                    long_text: '',
+                    quantity: 1.0,
+                    unit_price_net: 0.00,
+                    tax_rate_id: defaultTaxRateId,
+                    line_type: 'NORMAL'
+                })
             })
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                // Reset isDirty flag before reload to prevent warning
-                isDirty = false;
-                // Reload page to show new line
-                location.reload();
-            } else if (data.error) {
-                // Silent fail - no alert shown, just console log
-                console.error('Fehler beim Hinzufügen der Position:', data.error);
-            }
-        })
-        .catch(error => {
-            console.error('Error:', error);
-            // Silent fail - no alert shown
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    // Reset isDirty flag before reload to prevent warning
+                    isDirty = false;
+                    // Reload page to show new line
+                    location.reload();
+                } else if (data.error) {
+                    // Silent fail - no alert shown, just console log
+                    console.error('Fehler beim Hinzufügen der Position:', data.error);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                // Silent fail - no alert shown
+            });
         });
     }
     {% endif %}
@@ -1348,41 +1368,45 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             
             {% if document.pk %}
-            fetch('{% url "auftragsverwaltung:ajax_add_line" doc_key document.pk %}', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': '{{ csrf_token }}'
-                },
-                body: JSON.stringify({
-                    short_text_1: shortText1,
-                    short_text_2: shortText2,
-                    long_text: longText,
-                    quantity: parseFloat(quantity),
-                    unit_price_net: parseFloat(unitPrice),
-                    unit_id: unitId ? parseInt(unitId) : null,
-                    tax_rate_id: parseInt(taxRateId),
-                    kostenart1_id: kostenart1Id ? parseInt(kostenart1Id) : null,
-                    kostenart2_id: kostenart2Id ? parseInt(kostenart2Id) : null,
-                    line_type: 'NORMAL'
+            // Flush pending edits on other lines first, so the reload below
+            // can't drop a still-debounced save.
+            flushAllLineSaves().finally(function() {
+                fetch('{% url "auftragsverwaltung:ajax_add_line" doc_key document.pk %}', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': '{{ csrf_token }}'
+                    },
+                    body: JSON.stringify({
+                        short_text_1: shortText1,
+                        short_text_2: shortText2,
+                        long_text: longText,
+                        quantity: parseFloat(quantity),
+                        unit_price_net: parseFloat(unitPrice),
+                        unit_id: unitId ? parseInt(unitId) : null,
+                        tax_rate_id: parseInt(taxRateId),
+                        kostenart1_id: kostenart1Id ? parseInt(kostenart1Id) : null,
+                        kostenart2_id: kostenart2Id ? parseInt(kostenart2Id) : null,
+                        line_type: 'NORMAL'
+                    })
                 })
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    // Close modal and reload page
-                    const manualModal = bootstrap.Modal.getInstance(document.getElementById('manualLineModal'));
-                    if (manualModal) {
-                        manualModal.hide();
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        // Close modal and reload page
+                        const manualModal = bootstrap.Modal.getInstance(document.getElementById('manualLineModal'));
+                        if (manualModal) {
+                            manualModal.hide();
+                        }
+                        location.reload();
+                    } else if (data.error) {
+                        alert('Fehler: ' + data.error);
                     }
-                    location.reload();
-                } else if (data.error) {
-                    alert('Fehler: ' + data.error);
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                alert('Fehler beim Hinzufügen der Position');
+                })
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('Fehler beim Hinzufügen der Position');
+                });
             });
             {% else %}
             alert('Bitte speichern Sie das Dokument zuerst, bevor Sie Positionen hinzufügen.');
@@ -1569,33 +1593,37 @@ document.addEventListener('DOMContentLoaded', function() {
         if (articleSearchResults) {
             articleSearchResults.innerHTML = '';
         }
-        
-        fetch('{% url "auftragsverwaltung:ajax_add_line" doc_key document.pk %}', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-CSRFToken': '{{ csrf_token }}'
-            },
-            body: JSON.stringify({
-                item_id: article.id,
-                quantity: 1.0,
-                line_type: 'NORMAL',
-                kostenart1_id: article.cost_type_1_id,
-                kostenart2_id: article.cost_type_2_id
+
+        // Flush pending edits on other lines first, so the reload below can't
+        // drop a still-debounced save.
+        flushAllLineSaves().finally(function() {
+            fetch('{% url "auftragsverwaltung:ajax_add_line" doc_key document.pk %}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': '{{ csrf_token }}'
+                },
+                body: JSON.stringify({
+                    item_id: article.id,
+                    quantity: 1.0,
+                    line_type: 'NORMAL',
+                    kostenart1_id: article.cost_type_1_id,
+                    kostenart2_id: article.cost_type_2_id
+                })
             })
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                // Reload page to show new line
-                location.reload();
-            } else if (data.error) {
-                alert('Fehler: ' + data.error);
-            }
-        })
-        .catch(error => {
-            console.error('Error:', error);
-            alert('Fehler beim Hinzufügen der Position');
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    // Reload page to show new line
+                    location.reload();
+                } else if (data.error) {
+                    alert('Fehler: ' + data.error);
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Fehler beim Hinzufügen der Position');
+            });
         });
     }
     {% endif %}
@@ -1605,109 +1633,29 @@ document.addEventListener('DOMContentLoaded', function() {
     document.querySelectorAll('.delete-line-btn').forEach(btn => {
         btn.addEventListener('click', function() {
             if (!confirm('Position wirklich löschen?')) return;
-            
+
             const lineId = this.dataset.lineId;
-            fetch(`/auftragsverwaltung/ajax/documents/{{ doc_key }}/{{ document.pk }}/lines/${lineId}/delete/`, {
-                method: 'POST',
-                headers: {
-                    'X-CSRFToken': '{{ csrf_token }}'
-                }
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    location.reload();
-                } else if (data.error) {
-                    alert('Fehler: ' + data.error);
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                alert('Fehler beim Löschen der Position');
-            });
-        });
-    });
-    {% endif %}
-    
-    {% if document.pk %}
-    // Add change handlers for quantity and unit price to update calculations
-    document.querySelectorAll('.line-kostenart1').forEach(select => {
-        select.addEventListener('change', function() {
-            const lineId = this.dataset.lineId;
-            const kostenart1Id = this.value;
-            const lineItem = this.closest('.line-item');
-            const kostenart2Select = lineItem.querySelector('.line-kostenart2');
-            
-            // Update kostenart2 options
-            kostenart2Select.innerHTML = '<option value="">-- Keine --</option>';
-            
-            if (kostenart1Id) {
-                fetch(`{% url "auftragsverwaltung:ajax_get_kostenart2_options" %}?kostenart1_id=${kostenart1Id}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.kostenarten && data.kostenarten.length > 0) {
-                        data.kostenarten.forEach(k => {
-                            const option = document.createElement('option');
-                            option.value = k.id;
-                            option.textContent = k.name;
-                            kostenart2Select.appendChild(option);
-                        });
+            // Flush pending edits on other lines first, so the reload below
+            // can't drop a still-debounced save.
+            flushAllLineSaves().finally(function() {
+                fetch(`/auftragsverwaltung/ajax/documents/{{ doc_key }}/{{ document.pk }}/lines/${lineId}/delete/`, {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRFToken': '{{ csrf_token }}'
                     }
                 })
-                .catch(error => console.error('Error:', error));
-            }
-            
-            // Update the line with new kostenart1
-            fetch(`/auftragsverwaltung/ajax/documents/{{ doc_key }}/{{ document.pk }}/lines/${lineId}/update/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': '{{ csrf_token }}'
-                },
-                body: JSON.stringify({
-                    kostenart1_id: kostenart1Id ? parseInt(kostenart1Id) : null,
-                    kostenart2_id: null  // Reset kostenart2 when kostenart1 changes
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        location.reload();
+                    } else if (data.error) {
+                        alert('Fehler: ' + data.error);
+                    }
                 })
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (!data.success && data.error) {
-                    alert('Fehler: ' + data.error);
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                alert('Fehler beim Aktualisieren der Kostenart');
-            });
-        });
-    });
-    
-    // Kostenart 2 change in line items
-    document.querySelectorAll('.line-kostenart2').forEach(select => {
-        select.addEventListener('change', function() {
-            const lineId = this.dataset.lineId;
-            const kostenart2Id = this.value;
-            
-            // Update the line with new kostenart2
-            fetch(`/auftragsverwaltung/ajax/documents/{{ doc_key }}/{{ document.pk }}/lines/${lineId}/update/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': '{{ csrf_token }}'
-                },
-                body: JSON.stringify({
-                    kostenart2_id: kostenart2Id ? parseInt(kostenart2Id) : null
-                })
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (!data.success && data.error) {
-                    alert('Fehler: ' + data.error);
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                alert('Fehler beim Aktualisieren der Kostenart');
+                .catch(error => {
+                    console.error('Error:', error);
+                    alert('Fehler beim Löschen der Position');
+                });
             });
         });
     });
@@ -1901,20 +1849,11 @@ document.addEventListener('DOMContentLoaded', function() {
             const plainText = quillEditor.getText().trim();
             const cleanedHTML = plainText ? longtextHTML : '';
             
-            // Update the line via AJAX
-            fetch(`/auftragsverwaltung/ajax/documents/{{ doc_key }}/{{ document.pk }}/lines/${currentEditingLineId}/update/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': '{{ csrf_token }}'
-                },
-                body: JSON.stringify({
-                    long_text: cleanedHTML
-                })
-            })
-            .then(response => response.json())
+            // Update the line via the same queue as the other line fields, so
+            // this can't race a debounced autosave already pending for this line
+            saveLineFieldsNow(currentEditingLineId, { long_text: cleanedHTML })
             .then(data => {
-                if (data.success) {
+                if (data && data.success) {
                     // Update data store
                     const lineData = lineDataStore.get(currentEditingLineId);
                     if (lineData) {
@@ -1933,8 +1872,10 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                     
                     showToast('Langtext gespeichert', 'success');
-                } else if (data.error) {
+                } else if (data && data.error) {
                     alert('Fehler: ' + data.error);
+                } else {
+                    alert('Fehler beim Speichern des Langtexts');
                 }
             })
             .catch(error => {
@@ -2109,8 +2050,9 @@ document.addEventListener('DOMContentLoaded', function() {
             suggestionsDiv.style.display = 'none';
         }
         
-        // Update the line via AJAX
-        updateLineField(lineId, {
+        // Update the line via AJAX (goes through the queue so it can't race a
+        // save already pending for this line)
+        saveLineFieldsNow(lineId, {
             short_text_1: article.short_text_1 || '',
             short_text_2: article.short_text_2 || '',
             long_text: article.long_text || '',
@@ -2119,11 +2061,14 @@ document.addEventListener('DOMContentLoaded', function() {
             kostenart2_id: article.cost_type_2_id || null
         });
     }
-    
+
     {% if document.pk %}
-    // Update line field via AJAX
+    // Sends one line's field changes to the backend and reflects the result in
+    // the UI. This is the only function that actually POSTs to the update
+    // endpoint; scheduleLineSave/flushLineSave/saveLineFieldsNow above are what
+    // guarantee it's called at most once at a time per line.
     function updateLineField(lineId, data) {
-        fetch(`/auftragsverwaltung/ajax/documents/{{ doc_key }}/{{ document.pk }}/lines/${lineId}/update/`, {
+        return fetch(`/auftragsverwaltung/ajax/documents/{{ doc_key }}/{{ document.pk }}/lines/${lineId}/update/`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -2132,136 +2077,72 @@ document.addEventListener('DOMContentLoaded', function() {
             body: JSON.stringify(data)
         })
         .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                // Update totals if needed
-                if (data.line && data.line.line_net !== undefined) {
+        .then(result => {
+            if (result.success) {
+                if (result.line && result.line.line_net !== undefined) {
                     const lineItem = document.querySelector(`.line-item[data-line-id="${lineId}"]`);
                     if (lineItem) {
-                        const netSpan = lineItem.querySelector('.line-net');
-                        const taxSpan = lineItem.querySelector('.line-tax');
-                        const grossSpan = lineItem.querySelector('.line-gross');
-                        
-                        if (netSpan) netSpan.textContent = parseFloat(data.line.line_net).toFixed(2) + ' €';
-                        if (taxSpan) taxSpan.textContent = parseFloat(data.line.line_tax).toFixed(2) + ' €';
-                        if (grossSpan) grossSpan.textContent = parseFloat(data.line.line_gross).toFixed(2) + ' €';
+                        const netInput = lineItem.querySelector('.line-net');
+                        if (netInput) {
+                            netInput.value = parseFloat(result.line.line_net).toFixed(2) + ' €';
+                        }
                     }
                 }
-                
-                if (data.totals) {
-                    updateDocumentTotals(data.totals);
+
+                if (result.totals) {
+                    updateDocumentTotals(result.totals);
                 }
-            } else if (data.error) {
-                console.error('Update error:', data.error);
+            } else if (result.error) {
+                console.error('Update error:', result.error);
             }
+            return result;
         })
         .catch(error => {
             console.error('Error:', error);
         });
     }
+
+    // Single set of change/blur listeners for the six autosaved line fields
+    // (Kurztext 1, Menge, Einheit, Preis, Rabatt, USt) — replaces the former
+    // HTMX hx-post attributes and the duplicate updateLineField() listeners
+    // that both fired for the same field.
+    function bindLineAutosaveInput(el, extract) {
+        if (!el) return;
+        const lineItem = el.closest('.line-item');
+        const lineId = lineItem && lineItem.dataset.lineId;
+        if (!lineId) return;
+        el.addEventListener('input', function() {
+            scheduleLineSave(lineId, extract(el));
+        });
+        el.addEventListener('blur', function() {
+            flushLineSave(lineId);
+        });
+    }
+
+    function bindLineAutosaveSelect(el, extract) {
+        if (!el) return;
+        const lineItem = el.closest('.line-item');
+        const lineId = lineItem && lineItem.dataset.lineId;
+        if (!lineId) return;
+        el.addEventListener('change', function() {
+            saveLineFieldsNow(lineId, extract(el));
+        });
+    }
+
+    document.querySelectorAll('.line-short-text-1').forEach(el =>
+        bindLineAutosaveInput(el, input => ({ short_text_1: input.value })));
+    document.querySelectorAll('.line-quantity').forEach(el =>
+        bindLineAutosaveInput(el, input => ({ quantity: parseFloat(input.value) || 0 })));
+    document.querySelectorAll('.line-unit-price').forEach(el =>
+        bindLineAutosaveInput(el, input => ({ unit_price_net: parseFloat(input.value) || 0 })));
+    document.querySelectorAll('.line-discount').forEach(el =>
+        bindLineAutosaveInput(el, input => ({ discount: parseFloat(input.value) || 0 })));
+    document.querySelectorAll('.line-unit').forEach(el =>
+        bindLineAutosaveSelect(el, select => ({ unit_id: select.value ? parseInt(select.value) : null })));
+    document.querySelectorAll('.line-tax-rate').forEach(el =>
+        bindLineAutosaveSelect(el, select => ({ tax_rate_id: select.value ? parseInt(select.value) : null })));
     {% endif %}
-    
-    // Add change handlers for quantity and unit price to update calculations
-    document.querySelectorAll('.line-quantity, .line-unit-price').forEach(input => {
-        input.addEventListener('change', function() {
-            const lineItem = this.closest('.line-item');
-            if (!lineItem) return;
-            
-            const lineId = lineItem.dataset.lineId;
-            if (!lineId) return;
-            
-            const quantityInput = lineItem.querySelector('.line-quantity');
-            const unitPriceInput = lineItem.querySelector('.line-unit-price');
-            
-            if (!quantityInput || !unitPriceInput) return;
-            
-            const quantity = quantityInput.value;
-            const unitPrice = unitPriceInput.value;
-            
-            // Use || 0 to handle empty/invalid values
-            // Empty positions are allowed - clearing a field sends 0 to backend
-            updateLineField(lineId, {
-                quantity: parseFloat(quantity) || 0,
-                unit_price_net: parseFloat(unitPrice) || 0
-            });
-        });
-    });
-    
-    // Add change handler for description
-    document.querySelectorAll('.line-description').forEach(input => {
-        input.addEventListener('change', function() {
-            const lineItem = this.closest('.line-item');
-            if (!lineItem) return;
-            
-            const lineId = lineItem.dataset.lineId;
-            if (!lineId) return;
-            
-            const description = this.value;
-            
-            updateLineField(lineId, {
-                description: description
-            });
-        });
-    });
-    
-    // Add change handlers for short text fields
-    document.querySelectorAll('.line-short-text-2').forEach(input => {
-        input.addEventListener('change', function() {
-            const lineItem = this.closest('.line-item');
-            const lineId = lineItem.dataset.lineId;
-            const shortText2 = this.value;
-            
-            updateLineField(lineId, {
-                short_text_2: shortText2
-            });
-        });
-    });
-    
-    // Add change handlers for kostenart and tax rate
-    document.querySelectorAll('.line-kostenart1, .line-kostenart2, .line-tax-rate').forEach(select => {
-        select.addEventListener('change', function() {
-            const lineItem = this.closest('.line-item');
-            const lineId = lineItem.dataset.lineId;
-            
-            if (this.classList.contains('line-kostenart1')) {
-                const kostenart1Id = this.value;
-                updateLineField(lineId, {
-                    kostenart1_id: kostenart1Id ? parseInt(kostenart1Id) : null
-                });
-                
-                // Update kostenart2 options
-                const kostenart2Select = lineItem.querySelector('.line-kostenart2');
-                kostenart2Select.innerHTML = '<option value="">-- Keine --</option>';
-                
-                if (kostenart1Id) {
-                    fetch(`{% url "auftragsverwaltung:ajax_get_kostenart2_options" %}?kostenart1_id=${kostenart1Id}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.kostenarten && data.kostenarten.length > 0) {
-                            data.kostenarten.forEach(k => {
-                                const option = document.createElement('option');
-                                option.value = k.id;
-                                option.textContent = k.name;
-                                kostenart2Select.appendChild(option);
-                            });
-                        }
-                    })
-                    .catch(error => console.error('Error:', error));
-                }
-            } else if (this.classList.contains('line-kostenart2')) {
-                const kostenart2Id = this.value;
-                updateLineField(lineId, {
-                    kostenart2_id: kostenart2Id ? parseInt(kostenart2Id) : null
-                });
-            } else if (this.classList.contains('line-tax-rate')) {
-                const taxRateId = this.value;
-                updateLineField(lineId, {
-                    tax_rate_id: taxRateId ? parseInt(taxRateId) : null
-                });
-            }
-        });
-    });
-    
+
     // Function to update document totals
     function updateDocumentTotals(totals) {
         const totalNetEl = document.getElementById('totalNet');


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #936.

Model: Sonnet
Job: #114

---

## Zusammenfassung

- Ersetzt die zwei parallel laufenden Save-Systeme der Positionserfassung (HTMX-`hx-post` + manueller `updateLineField()`-fetch) durch einen einzigen, atomaren und serialisierten Save-Mechanismus pro Zeile in `templates/auftragsverwaltung/documents/detail.html`.
- Menge, Einheit, Preis, Rabatt, USt und Kurztext 1 feuerten bisher pro Änderung zwei konkurrierende POSTs auf denselben Endpunkt (`ajax_update_line`); jetzt läuft pro Zeile höchstens ein Request gleichzeitig.
- Add/Delete/Artikel-Auswahl/Speichern warten jetzt auf das Flushen aller offenen Zeilen-Saves, bevor sie einen Reload bzw. Formular-Submit auslösen, damit gerade getippte Werte nicht verloren gehen.

## Änderungen

- **Neue Save-Queue** (`lineSaveState`, `scheduleLineSave`, `flushLineSave`, `saveLineFieldsNow`, `flushAllLineSaves`, `hasPendingLineSaves`): bündelt alle in einer Zeile geänderten Felder in einem debounced (500 ms) Request und verkettet einen zweiten Save derselben Zeile hinter den ersten, statt ihn parallel abzusetzen.
- Die sechs Zeilenfelder (`line-short-text-1`, `line-quantity`, `line-unit`, `line-unit-price`, `line-discount`, `line-tax-rate`) verlieren ihre `hx-post`/`hx-trigger`/`hx-vals`/`hx-swap`-Attribute und tragen stattdessen die Markierung `line-autosave-field`; eine einzige JS-Bindung (`input`/`blur` für Texteingaben, `change` für Selects) ersetzt die frühere Doppelbindung.
- `updateLineField()` ist jetzt die einzige Stelle, die tatsächlich POSTet, gibt ihr Promise zurück und aktualisiert den Zeilennetto-Betrag korrekt über `.value` (vorher wurde per `.textContent` auf ein `<input readonly>` geschrieben, was sichtbar nie etwas bewirkte – maskiert durch den parallel laufenden HTMX-Pfad, der das gleiche Feld korrekt setzte).
- `addNewPosition()`, das manuelle Positions-Modal, `addLineFromArticle()` und der Lösch-Button rufen vor ihrem jeweiligen Request `flushAllLineSaves()` auf, damit ein anschließender `location.reload()` keine noch nicht abgeschickte Debounce-Änderung verwirft.
- Der Speichern-Button wartet ebenfalls auf `flushAllLineSaves()`, bevor er das Formular abschickt.
- Der Langtext-Editor (`saveLongtextButton`) und das Befüllen einer Zeile aus einem Artikelvorschlag (`fillLineFromArticle`) laufen jetzt über dieselbe Queue (`saveLineFieldsNow`) statt über einen eigenen, unkoordinierten `fetch`.
- `beforeunload` warnt zusätzlich, wenn noch Zeilen-Saves anstehen oder laufen (`hasPendingLineSaves()`), nicht nur bei "dirty" Kopfdaten.
- Entfernt toten Code: Zwei vollständige Change-Handler-Blöcke für `.line-kostenart1`/`.line-kostenart2`, die auf nicht existierende Elemente zielten (im Zeilen-Markup gibt es keine Kostenart-Selects), sowie tote Handler für `.line-description`/`.line-short-text-2`, die ebenfalls keine Entsprechung im gerenderten Markup hatten.
- Test-Anpassung in `auftragsverwaltung/test_unit_persistence.py`: `test_unit_select_has_name_attribute` erwartet jetzt die neue Klasse `line-unit line-autosave-field` statt der reinen HTMX-Klasse.

## Warum / Entscheidungen

- **Ein JS-Save statt durchgängig HTMX mit `hx-sync`**, weil die Abhängigkeit (Sub 1) den Endpunkt bereits robust gemacht hat (Feld-Level-`update_fields`, Row-Lock), aber das eigentliche Problem – Bündelung mehrerer Felder einer Zeile in einem Request plus Flush vor Reload/Submit – mit reinem HTMX nur über zusätzliche, schwer wartbare `hx-vals`-Merge-Logik lösbar gewesen wäre. Eine kleine, testbare JS-Queue bildet Debounce, Serialisierung und "vor Navigation flushen" direkt und explizit ab.
- **Nicht clientseitige Temp-ID → Real-ID-Verwaltung**, weil der bestehende Ablauf neue Zeilen ausschließlich über einen Server-Roundtrip anlegt (`ajax_add_line` → Reload mit echter PK); es existiert nie ein clientseitig editierbares Zeilenelement ohne echte PK. Das in der Analyse beschriebene Temp-ID-Risiko entsteht dadurch nicht mehr, solange vor diesem Reload alle Fremd-Zeilen-Edits geflusht sind (was diese Änderung sicherstellt) – eine zusätzliche Temp-ID-Abbildung wäre ungenutzte Komplexität für ein Szenario, das im aktuellen Design nicht auftritt.
- **Nicht `location.reload()` durch partielles Re-Render ersetzt**, weil der volle Reload nach Add/Delete/Artikel für die Positionsliste unproblematisch ist, sobald offene Zeilen-Saves vorher abgeschlossen sind; ein partielles Re-Render hätte den Diff unnötig vergrößert (neue Serialisierungs-/Merge-Logik für DOM-Patches) für einen Fall, der laut Akzeptanzkriterien nur "keine verlorenen Pending-Saves" verlangt, nicht "kein Reload".
- **Kopf-Felder (Betreff, Datum, Notizen) bleiben unberührt**, weil sie nie automatisch gespeichert wurden und der Datenverlust bei Reload dort ein separates, hier nicht beauftragtes Problem ist (dieses Sub-Issue betrifft explizit die Positions-Save-Schicht).
- **Debounce 500 ms statt sofortigem Send bei jedem Tastendruck**, weil sonst weiterhin ein Request pro Keystroke entstünde; 500 ms entspricht der bisherigen `keyup … delay:500ms`-Konvention für Kurztext 1 und wird nun einheitlich auf alle Texteingaben angewendet, kombiniert mit sofortigem Flush bei `blur`, damit ein Fokuswechsel nie eine Änderung "hängen" lässt.
- **Select-Felder (Einheit, USt) committen sofort statt debounced**, weil eine Auswahländerung ein diskreter, abgeschlossener Nutzeraktions-Moment ist (kein fortlaufendes Tippen) und ein Debounce hier nur unnötige Latenz ohne Bündelungsvorteil brächte.

## Test-Hinweise

- `python manage.py test auftragsverwaltung --settings=test_settings`: identisches Ergebnis vor und nach der Änderung (10 Errors/10 Failures, alle vorbestehend und nachweislich unabhängig von dieser Änderung – u. a. eine kaputte Decimal-Fixture in `test_document_create` und die bereits vor Sub 1 bekannten `test_line_save_hardening`-Fälle). Der einzige durch dieses Sub-Issue betroffene Test (`test_unit_select_has_name_attribute`) wurde angepasst und ist grün.
- Gerendertes JavaScript wurde sowohl im Create-Modus (`document.pk` nicht gesetzt) als auch im Edit-Modus (mit realen Positionszeilen) über den echten Django-Renderpfad extrahiert und mit `node --check` auf Syntaxfehler geprüft.
- Manuell nicht im Browser nachvollzogen (kein laufender Dev-Server in dieser Umgebung); empfohlen vor Merge: im Browser schnelles Tippen in Menge/Preis auf derselben Zeile, Netzwerk-Tab prüfen (genau ein Request pro Bündel), sowie Add/Delete direkt nach einer Zeilenänderung ohne Blur auslösen und nach Reload den Wert verifizieren.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core document line editing and persistence timing; race fixes reduce data loss risk but behavior changes (no HTMX, new debounce) warrant manual verification on fast edits and navigation.
> 
> **Overview**
> Fixes competing autosave on the sales document detail page by **removing HTMX `hx-post` from the six line fields** (Kurztext, quantity, unit, price, discount, tax) and routing all updates through a **single per-line save queue** in `detail.html`.
> 
> Field edits are **debounced (500 ms) and merged into one POST** per line; saves for the same line are **serialized** so two requests never run in parallel. **Add/delete line, article pick, long-text save, and document Speichern** now call `flushAllLineSaves()` first so a pending debounced edit is not lost on `location.reload()` or form submit. **`beforeunload`** also warns when line saves are still pending.
> 
> `updateLineField()` is the only code path that hits `ajax_update_line`; line net totals are updated via the readonly input’s **`.value`** (not `.textContent`). Dead handlers for non-rendered kostenart/description fields are removed. **`test_unit_select_has_name_attribute`** expects the new `line-autosave-field` class on the unit select.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 969203a5ac638721b523a2629ebaaccb4aab8986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->