### PR TITLE
UI/Bug: Gewählter Kunde unlesbar (helle Schrift auf hellem bg-light-Hintergrund) im Dark-Theme

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -94,6 +94,13 @@ body {
     border-top: 1px solid var(--border-color);
 }
 
+/* Selected-entity display (e.g. "Ausgewählt: <Kunde>") - dark theme contrast */
+.selected-entity-display {
+    background-color: var(--bg-card-hover);
+    border-color: var(--border-color) !important;
+    color: var(--text-primary);
+}
+
 /* Button Styles */
 .btn-primary {
     background-color: var(--primary-color);

--- a/templates/auftragsverwaltung/contracts/detail.html
+++ b/templates/auftragsverwaltung/contracts/detail.html
@@ -278,7 +278,7 @@ Vertrag: {{ contract.name }}
                                    value="{% if contract and contract.customer %}{{ contract.customer.pk }}{% endif %}">
                             <div id="customerSearchResults" class="customer-search-dropdown" style="display: none;"></div>
                             {% if contract and contract.customer %}
-                            <div id="selectedCustomerDisplay" class="mt-2 p-2 bg-light border rounded">
+                            <div id="selectedCustomerDisplay" class="mt-2 p-2 selected-entity-display border rounded">
                                 <strong>Ausgewählt:</strong> {{ contract.customer.full_name }}
                                 <button type="button" class="btn btn-sm btn-outline-danger float-end" onclick="clearCustomerSelection()">
                                     <i class="bi bi-x"></i>
@@ -1089,7 +1089,7 @@ $(document).ready(function() {
         if (!displayDiv) {
             displayDiv = document.createElement('div');
             displayDiv.id = 'selectedCustomerDisplay';
-            displayDiv.className = 'mt-2 p-2 bg-light border rounded';
+            displayDiv.className = 'mt-2 p-2 selected-entity-display border rounded';
             customerSearchInput.parentElement.appendChild(displayDiv);
         }
         displayDiv.innerHTML = `

--- a/templates/auftragsverwaltung/documents/detail.html
+++ b/templates/auftragsverwaltung/documents/detail.html
@@ -431,7 +431,7 @@ Neues {{ document_type.name }}
                                    value="{% if document and document.customer %}{{ document.customer.pk }}{% endif %}">
                             <div id="customerSearchResults" class="customer-search-dropdown" style="display: none;"></div>
                             {% if document and document.customer %}
-                            <div id="selectedCustomerDisplay" class="mt-2 p-2 bg-light border rounded">
+                            <div id="selectedCustomerDisplay" class="mt-2 p-2 selected-entity-display border rounded">
                                 <strong>Ausgewählt:</strong> {{ document.customer.full_name }}
                                 <button type="button" class="btn btn-sm btn-outline-danger float-end" onclick="clearCustomerSelection()">
                                     <i class="bi bi-x"></i>
@@ -1697,7 +1697,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!displayDiv) {
             displayDiv = document.createElement('div');
             displayDiv.id = 'selectedCustomerDisplay';
-            displayDiv.className = 'mt-2 p-2 bg-light border rounded';
+            displayDiv.className = 'mt-2 p-2 selected-entity-display border rounded';
             customerSearchInput.parentElement.appendChild(displayDiv);
         }
         displayDiv.innerHTML = `


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1043.

Model: Sonnet
Job: #223

---

## Zusammenfassung

Die „Ausgewählt: <Kunde>"-Box in der Kundenauswahl (Vertrag und Verkaufsdokument) war im Dark-Theme unlesbar, da sie mit `bg-light` einen hellen Hintergrund erhielt, während die globale Body-Textfarbe im Dark-Theme hell ist. Die Box nutzt jetzt eine zentrale, theme-konforme CSS-Klasse mit dunklem Hintergrund und garantiert lesbarer Textfarbe.

## Änderungen

- `static/css/site.css`: neue Klasse `.selected-entity-display` (Hintergrund `--bg-card-hover`, Rahmenfarbe `--border-color`, Textfarbe `--text-primary`).
- `templates/auftragsverwaltung/documents/detail.html`: `bg-light` durch `selected-entity-display` ersetzt — sowohl im server-gerenderten Markup (Zustand beim Laden) als auch im per JS erzeugten `displayDiv` (Zustand nach Auswahl).
- `templates/auftragsverwaltung/contracts/detail.html`: identische Anpassung an den analogen Stellen (Server-Render und JS-Erzeugung).

## Warum / Entscheidungen

- Neue zentrale CSS-Klasse statt direktem Ersetzen durch eine Bootstrap-Utility-Klasse (z. B. `bg-secondary`/`bg-dark`), weil dann Hintergrund- **und** Textfarbe an einer Stelle konsistent mit den bestehenden Dark-Theme-Variablen (`--bg-card-hover`, `--text-primary`, `--border-color`) definiert sind und nicht implizit von Bootstraps Default-Textfarbe abhängen.
- Nicht `bg-dark` verwendet, weil diese Klasse im Projekt bereits per `!important` auf `--bg-darker` (fast schwarz) gemappt ist und die Box dann kaum noch vom umgebenden Seitenhintergrund abgehoben wäre; `--bg-card-hover` (Slate 700) hebt sich sichtbar vom Body-Hintergrund (`--bg-dark`) ab.
- Nicht nur die Server-Render-Stelle korrigiert, weil die per JS erzeugte Box (`displayDiv.className`) exakt dasselbe `bg-light` gesetzt hat — ohne Anpassung dort wäre die Box direkt nach einer neuen Auswahl weiterhin unlesbar gewesen.
- Die in `mietobjekte/detail.html` und `vertraege/form.html` gefundenen weiteren `bg-light`-Vorkommen wurden nicht angefasst, weil es sich um andere Komponenten (Zähler-Karte, Vertragszusammenfassung) ohne das „Ausgewählt"-Muster handelt und eine Änderung dort außerhalb des gemeldeten Bugs liegen würde.

## Test-Hinweise

- `python manage.py test auftragsverwaltung vermietung --settings=test_settings` ausgeführt; die dabei auftretenden Fehler (u. a. `test_zaehler.py`, `test_document_create.py`, `test_timeentry.py`) bestehen unverändert auch ohne diese Änderung (verifiziert per `git stash` gegen den Ausgangsstand) und sind nicht auf diesen Fix zurückzuführen.
- `python manage.py makemigrations --check --settings=test_settings` liefert „No changes detected“ (reine Template-/CSS-Änderung, keine Modelländerung).
- Manuell zu prüfen: `/auftragsverwaltung/contracts/<id>/` und `/auftragsverwaltung/documents/invoice/<id>/` im Dark-Theme öffnen — die „Ausgewählt"-Box sollte sowohl beim initialen Laden mit bereits zugeordnetem Kunden als auch direkt nach Neuauswahl über die Suche klar lesbar sein.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS and template class swaps only; no auth, data, or business logic changes.
> 
> **Overview**
> Fixes unreadable **„Ausgewählt: &lt;Kunde&gt;“** boxes in contract and sales-document customer pickers in dark theme, where `bg-light` clashed with light body text.
> 
> Adds a shared **`selected-entity-display`** class in `site.css` using `--bg-card-hover`, `--border-color`, and `--text-primary`. Contract and document detail templates use it instead of `bg-light` for the selected-customer box on initial load and when JavaScript builds the box after search selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d16dd3ad2b2dd3be4d40f265d5d7003a65ec97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->