### PR TITLE
Bug: Rechnungslauf übernimmt Positionsdaten (Text/Preis) nicht aus dem Vertrag — leere Positionen

### DIFF
--- a/auftragsverwaltung/test_contract.py
+++ b/auftragsverwaltung/test_contract.py
@@ -840,3 +840,98 @@ class ContractBillingServiceTestCase(TestCase):
         self.assertEqual(sales_line.long_text, "This is a detailed long text description for the contract line.")
         self.assertEqual(sales_line.description, "Monthly Service with Kurztext")
 
+    def test_generate_due_multiple_lines_full_position_data(self):
+        """Regression test: a contract with several positions (different tax rates/prices)
+        must produce a SalesDocument whose lines carry the full ContractLine data
+        (texts, quantity, price, tax rate) and correctly calculated totals."""
+        tax_rate_7 = TaxRate.objects.create(
+            code="VAT_7",
+            name="7% VAT",
+            rate=Decimal('0.07'),
+            is_active=True
+        )
+
+        contract = Contract.objects.create(
+            company=self.company,
+            name="Test Contract Multi-Line",
+            customer=self.customer,
+            document_type=self.doc_type,
+            payment_term=self.payment_term,
+            currency='EUR',
+            interval='MONTHLY',
+            start_date=date(2026, 1, 1),
+            next_run_date=date(2026, 1, 1),
+            is_active=True
+        )
+
+        line_1 = ContractLine.objects.create(
+            contract=contract,
+            position_no=1,
+            short_text_1="Leasingrate",
+            short_text_2="Fahrzeug",
+            long_text="Monatliche Leasingrate für Fahrzeug XY",
+            description="Monatliche Leasingrate",
+            quantity=Decimal('1.0000'),
+            unit_price_net=Decimal('1000.00'),
+            tax_rate=self.tax_rate,
+            cost_type_1=self.cost_type,
+            is_discountable=True
+        )
+        line_2 = ContractLine.objects.create(
+            contract=contract,
+            position_no=2,
+            short_text_1="Wartungspauschale",
+            short_text_2="",
+            long_text="Monatliche Wartungspauschale",
+            description="Wartungspauschale",
+            quantity=Decimal('3.0000'),
+            unit_price_net=Decimal('50.00'),
+            tax_rate=tax_rate_7,
+            cost_type_2=self.cost_type2,
+            is_discountable=False
+        )
+
+        runs = ContractBillingService.generate_due(today=date(2026, 1, 1))
+
+        self.assertEqual(len(runs), 1)
+        run = runs[0]
+        self.assertEqual(run.status, 'SUCCESS')
+        document = run.document
+
+        lines = list(document.lines.order_by('position_no'))
+        self.assertEqual(len(lines), 2)
+
+        sales_line_1, sales_line_2 = lines
+
+        self.assertEqual(sales_line_1.position_no, 1)
+        self.assertEqual(sales_line_1.short_text_1, line_1.short_text_1)
+        self.assertEqual(sales_line_1.short_text_2, line_1.short_text_2)
+        self.assertEqual(sales_line_1.long_text, line_1.long_text)
+        self.assertEqual(sales_line_1.description, line_1.description)
+        self.assertEqual(sales_line_1.quantity, line_1.quantity)
+        self.assertEqual(sales_line_1.unit_price_net, line_1.unit_price_net)
+        self.assertEqual(sales_line_1.tax_rate, self.tax_rate)
+        self.assertEqual(sales_line_1.kostenart1, self.cost_type)
+        self.assertTrue(sales_line_1.is_discountable)
+
+        self.assertEqual(sales_line_2.position_no, 2)
+        self.assertEqual(sales_line_2.short_text_1, line_2.short_text_1)
+        self.assertEqual(sales_line_2.long_text, line_2.long_text)
+        self.assertEqual(sales_line_2.description, line_2.description)
+        self.assertEqual(sales_line_2.quantity, line_2.quantity)
+        self.assertEqual(sales_line_2.unit_price_net, line_2.unit_price_net)
+        self.assertEqual(sales_line_2.tax_rate, tax_rate_7)
+        self.assertEqual(sales_line_2.kostenart2, self.cost_type2)
+        self.assertFalse(sales_line_2.is_discountable)
+
+        # None of the position data may be empty/zero
+        for sales_line in (sales_line_1, sales_line_2):
+            self.assertTrue(sales_line.description)
+            self.assertGreater(sales_line.unit_price_net, Decimal('0.00'))
+            self.assertGreater(sales_line.quantity, Decimal('0.0000'))
+
+        # Totals: 1x1000.00 @19% + 3x50.00 @7% = 1150.00 net, 190.00 + 10.50 tax
+        self.assertEqual(document.total_net, Decimal('1150.00'))
+        self.assertEqual(document.total_tax, Decimal('200.50'))
+        self.assertEqual(document.total_gross, Decimal('1350.50'))
+


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1044.

Model: Sonnet
Job: #226

---

## Zusammenfassung

Der gemeldete Bug ("Rechnungslauf übernimmt Positionsdaten nicht aus dem Vertrag") ist im aktuellen Code bereits behoben: `ContractBillingService._generate_invoice` in `auftragsverwaltung/services/contract_billing.py` kopiert beim Erzeugen einer `SalesDocumentLine` bereits alle relevanten Felder (`short_text_1`, `short_text_2`, `long_text`, `description`, `quantity`, `unit_price_net`, `tax_rate`, `is_discountable`, `item`, `kostenart1`/`kostenart2`) aus der zugehörigen `ContractLine` und ruft anschließend `DocumentCalculationService.recalculate(document, persist=True)` auf, sodass Summen korrekt berechnet werden.

Diese PR ergänzt den in den Akzeptanzkriterien geforderten Regressionstest, der bislang fehlte: ein Vertrag mit **zwei Positionen mit unterschiedlichen Steuersätzen und Preisen**, dessen Rechnungslauf vollständige Positionsdaten und korrekt berechnete Summen liefert.

## Änderungen

- `auftragsverwaltung/test_contract.py`: neuer Test `test_generate_due_multiple_lines_full_position_data` in `ContractBillingServiceTestCase`. Legt einen Vertrag mit zwei `ContractLine`-Positionen (19 % und 7 % Steuersatz, unterschiedliche Mengen/Preise, unterschiedliche Kostenarten, unterschiedliches `is_discountable`) an, führt `ContractBillingService.generate_due` aus und prüft:
  - beide `SalesDocumentLine`-Einträge übernehmen Kurztext 1/2, Langtext, Beschreibung, Menge, Netto-Stückpreis, Steuersatz und Kostenart 1:1 aus der jeweiligen `ContractLine`,
  - `position_no` bleibt erhalten,
  - keine Position hat leere Beschreibung oder Preis/Menge = 0,
  - `total_net`/`total_tax`/`total_gross` des erzeugten Dokuments sind korrekt (1150,00 € / 200,50 € / 1350,50 €).

## Warum / Entscheidungen

- Keine Änderung an `contract_billing.py` vorgenommen, weil die Feldkopie inkl. Kurztexten bereits vollständig vorhanden ist (siehe Commit „Add kurztext fields to ContractLine and copy to SalesDocumentLine during billing"). Der bestehende Test `test_generate_due_success` sowie `test_kurztext_fields_copied_to_sales_document_line` decken bereits den Ein-Positionen-Fall inkl. Texten, Preis, Steuersatz und Kostenarten ab; eine erneute Implementierung hätte nur bereits korrekten Code dupliziert.
- Nicht auf eine Anpassung des Bug-Tickets/Schließen ohne Codeänderung verzichtet, weil das explizite Akzeptanzkriterium „Vertrag mit ≥2 Positionen (unterschiedliche Steuersätze/Preise)" bislang durch keinen Test abgedeckt war — dieser Fall (mehrere Positionen mit unterschiedlichen Steuersätzen) ist der einzige Teil des Bug-Reports, der noch nicht durch bestehende Tests verifiziert war.
- Nicht den bestehenden Test `test_generate_due_success` erweitert, sondern einen eigenen Testfall ergänzt, weil die Akzeptanzkriterien explizit einen dedizierten Regressionstest mit mehreren Positionen/Steuersätzen verlangen und ein eigenständiger Test unabhängig von künftigen Änderungen an `test_generate_due_success` bestehen bleibt.
- Nicht `unit` auf der `SalesDocumentLine` befüllt, weil `ContractLine` kein Mengeneinheit-Feld besitzt und `unit` in `SalesDocumentLine` nullable ist — der bestehende Code lässt es korrekt `None`, das entspricht der in den Akzeptanzkriterien vorgesehenen sinnvollen Default-Behandlung.

## Test-Hinweise

- `python manage.py test auftragsverwaltung.test_contract --settings=test_settings` — 24 Tests, alle grün (inkl. neuem Regressionstest).
- `python manage.py test auftragsverwaltung --settings=test_settings` — bestehende, von dieser Änderung unabhängige Fehlschläge (u. a. `test_document_create`, `test_number_range`, `test_timeentry`, `test_line_save_hardening`) wurden vor der Änderung auf dem Ausgangsstand des Branches verifiziert und sind nicht auf diese PR zurückzuführen.
- `python manage.py makemigrations --check --dry-run --settings=test_settings` — keine Änderungen erkannt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or billing logic modifications.
> 
> **Overview**
> Adds **`test_generate_due_multiple_lines_full_position_data`** in `auftragsverwaltung/test_contract.py` — no production code changes.
> 
> The test builds a monthly contract with **two** `ContractLine` rows (19% and 7% VAT, different quantities/prices, cost types, and `is_discountable`), runs `ContractBillingService.generate_due`, and asserts each `SalesDocumentLine` mirrors the contract line (kurztext fields, description, quantity, net price, tax rate, kostenart) and that document **net/tax/gross** match the combined calculation (1150.00 / 200.50 / 1350.50).
> 
> This closes the acceptance gap for the reported bug (empty positions on billing runs) by locking in the multi-position, mixed-tax scenario that existing single-line tests did not cover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97efaba9678e692acd070f049631b7b00b9397cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->