### PR TITLE
Positionstexte vereinheitlichen: ContractLine & SalesDocumentLine auf Kurztext 1 + Langtext führen (verlustfreie Migration)

### DIFF
--- a/auftragsverwaltung/migrations/0023_migrate_contractline_description_to_texts.py
+++ b/auftragsverwaltung/migrations/0023_migrate_contractline_description_to_texts.py
@@ -1,0 +1,85 @@
+"""
+Verlustfreie Überführung bestehender ContractLine-Texte.
+
+Historisch pflegte die Vertrags-UI Positionstexte ausschließlich in
+``description``; ``short_text_1``/``long_text`` blieben leer. Das Rechnungs-Grid
+rendert aber ``short_text_1``/``long_text``, sodass die Texte in erzeugten
+Rechnungen optisch leer wirkten (siehe Issue #1044/#1053).
+
+Diese Datenmigration befüllt die führenden Felder aus ``description``:
+
+* Für jede ``ContractLine`` mit **leerem** ``short_text_1`` und **nicht-leerem**
+  ``description``: ``short_text_1`` wird aus der ersten Zeile von ``description``
+  gesetzt (an Wortgrenze auf 200 Zeichen gekürzt).
+* Passt der Text nicht in 200 Zeichen **oder** ist er mehrzeilig **und**
+  ``long_text`` ist leer, wird der **vollständige** ``description``-Text nach
+  ``long_text`` übernommen – so geht kein Zeichen verloren.
+* ``description`` wird **nie** gelöscht oder überschrieben.
+
+Die Migration ist idempotent (Zeilen mit bereits gesetztem ``short_text_1``
+werden übersprungen) und reversibel als No-op (das Befüllen leerer Zielfelder
+ist ohnehin nicht destruktiv).
+"""
+
+from django.db import migrations
+
+SHORT_TEXT_MAX_LENGTH = 200
+
+
+def _shorten_to_short_text(text, limit=SHORT_TEXT_MAX_LENGTH):
+    """Kürze ``text`` auf höchstens ``limit`` Zeichen an einer Wortgrenze."""
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    cut = text[:limit]
+    # An letzter Leerstelle brechen, um kein Wort mittendrin abzuschneiden.
+    # Nur, wenn der Bruch nicht zu früh liegt (mind. Hälfte des Limits).
+    space_idx = cut.rfind(' ')
+    if space_idx >= limit // 2:
+        cut = cut[:space_idx]
+    return cut.rstrip()
+
+
+def forwards(apps, schema_editor):
+    ContractLine = apps.get_model('auftragsverwaltung', 'ContractLine')
+
+    for line in ContractLine.objects.all().iterator():
+        description = (line.description or '').strip()
+        if not description:
+            continue
+        # Idempotenz: Zeilen mit bereits gepflegtem Kurztext bleiben unverändert.
+        if (line.short_text_1 or '').strip():
+            continue
+
+        first_line = description.split('\n', 1)[0].strip()
+        is_multiline = '\n' in description
+        needs_long_text = is_multiline or len(first_line) > SHORT_TEXT_MAX_LENGTH
+
+        update_fields = []
+        line.short_text_1 = _shorten_to_short_text(first_line)
+        update_fields.append('short_text_1')
+
+        # Vollständigen Text nur nach long_text übernehmen, wenn dort noch nichts
+        # steht – sonst würde vorhandener Langtext überschrieben.
+        if needs_long_text and not (line.long_text or '').strip():
+            line.long_text = description
+            update_fields.append('long_text')
+
+        line.save(update_fields=update_fields)
+
+
+def backwards(apps, schema_editor):
+    """No-op: Das Befüllen leerer Felder ist nicht destruktiv, da ``description``
+    unangetastet bleibt und weiterhin die vollständige Quelle darstellt."""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auftragsverwaltung', '0022_contractline_unit'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/auftragsverwaltung/test_contract.py
+++ b/auftragsverwaltung/test_contract.py
@@ -944,3 +944,191 @@ class ContractBillingServiceTestCase(TestCase):
         self.assertEqual(document.total_tax, Decimal('200.50'))
         self.assertEqual(document.total_gross, Decimal('1350.50'))
 
+
+class ContractLineTextUnificationTestCase(TestCase):
+    """
+    Regression tests for unifying ContractLine and SalesDocumentLine text
+    structure (short_text_1 + long_text as leading fields) and the lossless
+    migration of legacy description-only data.
+    """
+
+    def setUp(self):
+        self.company = Mandant.objects.create(
+            name="Test Company",
+            adresse="Test Street 1",
+            plz="12345",
+            ort="Test City",
+        )
+        self.customer = Adresse.objects.create(
+            name="Test Customer",
+            strasse="Customer Street 1",
+            plz="54321",
+            ort="Customer City",
+            land="Germany",
+        )
+        self.doc_type = DocumentType.objects.get(key="invoice")
+        self.payment_term = PaymentTerm.objects.create(
+            name="Net 30", net_days=30, is_default=True
+        )
+        self.tax_19 = TaxRate.objects.create(
+            code="VAT_19", name="19% VAT", rate=Decimal('0.19'), is_active=True
+        )
+        self.tax_7 = TaxRate.objects.create(
+            code="VAT_7", name="7% VAT", rate=Decimal('0.07'), is_active=True
+        )
+        self.unit = Unit.objects.create(code="MON", name="Monat")
+        NumberRange.objects.create(
+            company=self.company,
+            target='CONTRACT',
+            reset_policy='YEARLY',
+            format='V{yy}-{seq:05d}',
+        )
+        self.contract = Contract.objects.create(
+            company=self.company,
+            name="Test Contract",
+            customer=self.customer,
+            document_type=self.doc_type,
+            payment_term=self.payment_term,
+            currency='EUR',
+            interval='MONTHLY',
+            start_date=date(2026, 1, 1),
+            next_run_date=date(2026, 1, 1),
+            is_active=True,
+        )
+
+    def test_billing_copies_leading_text_fields_visibly(self):
+        """
+        Billing must carry short_text_1 (and long_text) to the invoice line so
+        the text is visible in the invoice grid (retest case from #1044/#1053).
+        Also verifies quantity/price/tax/unit and ordering for two lines with
+        different tax rates.
+        """
+        line_1 = ContractLine.objects.create(
+            contract=self.contract,
+            position_no=1,
+            short_text_1="KFZ Miete Hyundai i30 Grau LA-HR-1111",
+            long_text="Inkl. Versicherung und Wartung",
+            description="KFZ Miete Hyundai i30 Grau LA-HR-1111\nInkl. Versicherung und Wartung",
+            unit=self.unit,
+            quantity=Decimal('1.0000'),
+            unit_price_net=Decimal('1000.00'),
+            tax_rate=self.tax_19,
+            is_discountable=True,
+        )
+        line_2 = ContractLine.objects.create(
+            contract=self.contract,
+            position_no=2,
+            short_text_1="Zusatzleistung",
+            long_text="",
+            description="Zusatzleistung",
+            quantity=Decimal('3.0000'),
+            unit_price_net=Decimal('50.00'),
+            tax_rate=self.tax_7,
+            is_discountable=False,
+        )
+
+        runs = ContractBillingService.generate_due(today=date(2026, 1, 1))
+        self.assertEqual(len(runs), 1)
+        document = runs[0].document
+
+        sales_lines = list(document.lines.order_by('position_no'))
+        self.assertEqual(len(sales_lines), 2)
+        sl1, sl2 = sales_lines
+
+        # Leading text fields are visible on the invoice line
+        self.assertEqual(sl1.short_text_1, line_1.short_text_1)
+        self.assertEqual(sl1.long_text, line_1.long_text)
+        self.assertEqual(sl2.short_text_1, line_2.short_text_1)
+
+        # Regression to #1044: quantity, price, tax and unit carry over
+        self.assertEqual(sl1.position_no, 1)
+        self.assertEqual(sl1.quantity, Decimal('1.0000'))
+        self.assertEqual(sl1.unit_price_net, Decimal('1000.00'))
+        self.assertEqual(sl1.tax_rate, self.tax_19)
+        self.assertEqual(sl1.unit, self.unit)
+        self.assertEqual(sl2.position_no, 2)
+        self.assertEqual(sl2.tax_rate, self.tax_7)
+
+        # Totals: 1x1000.00 @19% + 3x50.00 @7%
+        self.assertEqual(document.total_net, Decimal('1150.00'))
+        self.assertEqual(document.total_tax, Decimal('200.50'))
+        self.assertEqual(document.total_gross, Decimal('1350.50'))
+
+    def _run_forward_migration(self):
+        """Invoke the data migration's forward function against the real model."""
+        import importlib
+
+        module = importlib.import_module(
+            'auftragsverwaltung.migrations.'
+            '0023_migrate_contractline_description_to_texts'
+        )
+
+        class _Apps:
+            def get_model(self, app_label, model_name):
+                return ContractLine
+
+        module.forwards(_Apps(), None)
+
+    def _make_line(self, position_no, description, short_text_1="", long_text=""):
+        return ContractLine.objects.create(
+            contract=self.contract,
+            position_no=position_no,
+            short_text_1=short_text_1,
+            long_text=long_text,
+            description=description,
+            quantity=Decimal('1.0000'),
+            unit_price_net=Decimal('10.00'),
+            tax_rate=self.tax_19,
+        )
+
+    def test_migration_migrates_description_only_lines_losslessly(self):
+        """description-only lines get short_text_1 (+ long_text) without data loss."""
+        short_line = self._make_line(1, "KFZ Miete Hyundai i30")
+        multiline = self._make_line(2, "Erste Zeile\nZweite Zeile mit Details")
+        long_desc = " ".join(["Wort"] * 60)  # 299 chars, single line, no trailing space
+        long_single = self._make_line(3, long_desc)
+        already_set = self._make_line(4, "Beschreibung", short_text_1="Bestehend")
+
+        self._run_forward_migration()
+
+        # Short single line -> copied verbatim into short_text_1, long_text stays empty
+        short_line.refresh_from_db()
+        self.assertEqual(short_line.short_text_1, "KFZ Miete Hyundai i30")
+        self.assertEqual(short_line.long_text, "")
+        self.assertEqual(short_line.description, "KFZ Miete Hyundai i30")  # untouched
+
+        # Multiline -> first line to short_text_1, full text preserved in long_text
+        multiline.refresh_from_db()
+        self.assertEqual(multiline.short_text_1, "Erste Zeile")
+        self.assertEqual(multiline.long_text, "Erste Zeile\nZweite Zeile mit Details")
+        self.assertEqual(multiline.description, "Erste Zeile\nZweite Zeile mit Details")
+
+        # Long single line -> short_text_1 truncated to <= 200 at a word boundary,
+        # full text preserved in long_text
+        long_single.refresh_from_db()
+        self.assertLessEqual(len(long_single.short_text_1), 200)
+        self.assertTrue(long_single.short_text_1)
+        self.assertFalse(long_single.short_text_1.endswith(' '))
+        self.assertTrue(long_desc.startswith(long_single.short_text_1))
+        self.assertEqual(long_single.long_text, long_desc)
+        self.assertEqual(long_single.description, long_desc)
+
+        # Line that already had a short_text_1 is left untouched
+        already_set.refresh_from_db()
+        self.assertEqual(already_set.short_text_1, "Bestehend")
+        self.assertEqual(already_set.long_text, "")
+
+    def test_migration_is_idempotent(self):
+        """Running the migration twice does not change already-migrated data."""
+        multiline = self._make_line(1, "Kopf\nDetails hier")
+
+        self._run_forward_migration()
+        multiline.refresh_from_db()
+        first_short = multiline.short_text_1
+        first_long = multiline.long_text
+
+        self._run_forward_migration()
+        multiline.refresh_from_db()
+        self.assertEqual(multiline.short_text_1, first_short)
+        self.assertEqual(multiline.long_text, first_long)
+

--- a/auftragsverwaltung/test_contract_views.py
+++ b/auftragsverwaltung/test_contract_views.py
@@ -104,6 +104,7 @@ class ContractViewTestCase(TestCase):
         self.contract_line = ContractLine.objects.create(
             contract=self.contract,
             position_no=1,
+            short_text_1='Test Service',
             description='Test Service',
             quantity=Decimal('1.0000'),
             unit_price_net=Decimal('100.00'),
@@ -337,30 +338,53 @@ class ContractAjaxEndpointTestCase(TestCase):
         url = reverse('auftragsverwaltung:ajax_contract_add_line', kwargs={'pk': self.contract.pk})
         
         data = {
-            'description': 'New Test Line',
+            'short_text_1': 'New Test Line',
+            'long_text': 'Detaillierter Langtext',
             'quantity': '2.0000',
             'unit_price_net': '50.00',
             'tax_rate_id': self.tax_rate.pk,
             'is_discountable': True,
         }
-        
+
         response = self.client.post(
             url,
             data=json.dumps(data),
             content_type='application/json'
         )
-        
+
         self.assertEqual(response.status_code, 200)
-        
+
         response_data = json.loads(response.content)
         self.assertTrue(response_data['success'])
         self.assertIn('line', response_data)
         self.assertIn('preview_totals', response_data)
-        
-        # Check that line was created
-        line = ContractLine.objects.get(contract=self.contract, description='New Test Line')
+
+        # Check that line was created with the leading text fields populated
+        line = ContractLine.objects.get(contract=self.contract, short_text_1='New Test Line')
+        self.assertEqual(line.long_text, 'Detaillierter Langtext')
+        # description is a generated, secondary field built from the short texts
+        self.assertEqual(line.description, 'New Test Line\nDetaillierter Langtext')
         self.assertEqual(line.quantity, Decimal('2.0000'))
         self.assertEqual(line.unit_price_net, Decimal('50.00'))
+
+    def test_ajax_add_line_requires_short_text_1(self):
+        """A manual line without short_text_1 is rejected."""
+        url = reverse('auftragsverwaltung:ajax_contract_add_line', kwargs={'pk': self.contract.pk})
+
+        data = {
+            'quantity': '2.0000',
+            'unit_price_net': '50.00',
+            'tax_rate_id': self.tax_rate.pk,
+        }
+
+        response = self.client.post(
+            url,
+            data=json.dumps(data),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Kurztext 1', json.loads(response.content)['error'])
     
     def test_ajax_update_line(self):
         """Test updating a line via AJAX"""
@@ -379,27 +403,31 @@ class ContractAjaxEndpointTestCase(TestCase):
                      kwargs={'pk': self.contract.pk, 'line_id': line.pk})
         
         data = {
-            'description': 'Updated Description',
+            'short_text_1': 'Updated Short Text',
+            'long_text': 'Updated Long Text',
             'quantity': '3.0000',
             'unit_price_net': '75.00',
         }
-        
+
         response = self.client.post(
             url,
             data=json.dumps(data),
             content_type='application/json'
         )
-        
+
         self.assertEqual(response.status_code, 200)
-        
+
         response_data = json.loads(response.content)
         self.assertTrue(response_data['success'])
         self.assertIn('line', response_data)
         self.assertIn('preview_totals', response_data)
-        
-        # Check that line was updated
+
+        # Check that line was updated: leading text fields persisted and
+        # description regenerated from them
         line.refresh_from_db()
-        self.assertEqual(line.description, 'Updated Description')
+        self.assertEqual(line.short_text_1, 'Updated Short Text')
+        self.assertEqual(line.long_text, 'Updated Long Text')
+        self.assertEqual(line.description, 'Updated Short Text\nUpdated Long Text')
         self.assertEqual(line.quantity, Decimal('3.0000'))
         self.assertEqual(line.unit_price_net, Decimal('75.00'))
     

--- a/auftragsverwaltung/views.py
+++ b/auftragsverwaltung/views.py
@@ -54,6 +54,30 @@ def normalize_foreign_key_id(value):
     return value
 
 
+def _build_contract_line_description(short_text_1, short_text_2='', long_text=''):
+    """
+    Build the (secondary) description of a contract line from its short texts.
+
+    short_text_1 and long_text are the leading, user-facing fields; description is a
+    generated convenience/fallback field and must never replace short_text_1. The
+    long_text may contain sanitized HTML, so tags are stripped for the plain-text
+    description.
+
+    Returns:
+        str: newline-joined non-empty parts, or '' if nothing is set.
+    """
+    parts = []
+    if short_text_1:
+        parts.append(short_text_1)
+    if short_text_2:
+        parts.append(short_text_2)
+    if long_text:
+        stripped = strip_tags(long_text).strip()
+        if stripped:
+            parts.append(stripped)
+    return '\n'.join(parts)
+
+
 def normalize_decimal_input(value):
     """
     Normalize decimal input from various formats (German and English).
@@ -1646,7 +1670,10 @@ def ajax_contract_add_line(request, pk):
     POST parameters (JSON):
         - item_id: Item/Article ID (optional for manual lines)
         - quantity: Quantity
-        - description: Description (required for manual lines)
+        - short_text_1: Primary short text (required for manual lines; leading field)
+        - short_text_2: Optional second short text
+        - long_text: Optional long text (sanitized)
+        - description: Legacy fallback; otherwise generated from the short texts
         - unit_id: Unit of measure ID (optional)
         - unit_price_net: Unit price (required for manual lines)
         - tax_rate_id: Tax rate ID (required)
@@ -1665,6 +1692,9 @@ def ajax_contract_add_line(request, pk):
 
         item_id = data.get('item_id')
         description = data.get('description', '')
+        short_text_1 = data.get('short_text_1', '')
+        short_text_2 = data.get('short_text_2', '')
+        long_text = data.get('long_text', '')
         unit_id = data.get('unit_id')
         tax_rate_id = data.get('tax_rate_id')
         cost_type_1_id = data.get('cost_type_1_id')
@@ -1683,31 +1713,46 @@ def ajax_contract_add_line(request, pk):
         if item_id:
             # Article-based line
             item = get_object_or_404(Item, pk=item_id)
-            
-            # Use item data
-            if not description:
-                description = f"{item.short_text_1}\n{item.long_text}" if item.long_text else item.short_text_1
+
+            # Use item data as fallback for any text field the caller did not supply
+            if not short_text_1:
+                short_text_1 = item.short_text_1
+            if not short_text_2:
+                short_text_2 = item.short_text_2
+            if not long_text:
+                long_text = item.long_text
             if not unit_price_net:
                 unit_price_net = item.net_price  # Already a Decimal from the model
-            
+
             # Use item's tax rate if not provided
             if not tax_rate_id and item.tax_rate:
                 tax_rate_id = item.tax_rate.pk
-            
+
             # Use item's cost types if not provided
             if not cost_type_1_id and item.kostenart1:
                 cost_type_1_id = item.kostenart1.pk
             if not cost_type_2_id and item.kostenart2:
                 cost_type_2_id = item.kostenart2.pk
-            
+
             is_discountable = item.is_discountable
         else:
-            # Manual line - ensure required fields are present
-            if not description:
-                return JsonResponse({'error': 'Beschreibung ist erforderlich'}, status=400)
+            # Manual line - ensure required fields are present.
+            # Backward compatibility: legacy callers may still send only `description`.
+            # Seed the leading text fields from it so no text is lost.
+            if not short_text_1 and description:
+                first_line = description.split('\n', 1)[0].strip()
+                short_text_1 = first_line[:200]
+                if not long_text and ('\n' in description or len(first_line) > 200):
+                    long_text = description
+            if not short_text_1:
+                return JsonResponse({'error': 'Kurztext 1 ist erforderlich'}, status=400)
             if not unit_price_net:
                 return JsonResponse({'error': 'Netto-Stückpreis ist erforderlich'}, status=400)
-        
+
+        # Generate description consistently from the short texts. It is a secondary
+        # display field and must never replace short_text_1.
+        description = _build_contract_line_description(short_text_1, short_text_2, long_text)
+
         # Ensure tax rate is provided
         if not tax_rate_id:
             return JsonResponse({'error': 'Steuersatz ist erforderlich'}, status=400)
@@ -1733,6 +1778,12 @@ def ajax_contract_add_line(request, pk):
             contract=contract,
             item_id=item_id if item_id else None,
             position_no=position_no,
+            short_text_1=short_text_1,
+            short_text_2=short_text_2,
+            # long_text is rendered with the `|safe` filter in PDF templates, so it must be
+            # bleach-sanitized. short_text_1/2 and description are always auto-escaped by
+            # Django templates and stored as plain text, so no sanitization is applied there.
+            long_text=sanitize_html(long_text) if long_text else '',
             description=description,
             unit_id=normalize_foreign_key_id(unit_id),
             quantity=quantity,
@@ -1765,6 +1816,9 @@ def ajax_contract_add_line(request, pk):
             'line': {
                 'id': line.pk,
                 'position_no': line.position_no,
+                'short_text_1': line.short_text_1,
+                'short_text_2': line.short_text_2,
+                'long_text': line.long_text,
                 'description': line.description,
                 'unit_id': line.unit.pk if line.unit else None,
                 'unit_code': line.unit.code if line.unit else '',
@@ -1797,7 +1851,10 @@ def ajax_contract_update_line(request, pk, line_id):
     POST parameters (JSON):
         - quantity: New quantity
         - unit_price_net: New unit price
-        - description: New description
+        - short_text_1: New primary short text (leading field)
+        - short_text_2: New second short text
+        - long_text: New long text (sanitized)
+        - description: Legacy field; regenerated from the short texts when those change
         - unit_id: New unit of measure ID
         - tax_rate_id: New tax rate ID
         - cost_type_1_id: New cost type 1 ID
@@ -1827,7 +1884,22 @@ def ajax_contract_update_line(request, pk, line_id):
             except (ValueError, TypeError) as e:
                 return JsonResponse({'error': f'Ungültiger Netto-Stückpreis: {str(e)}'}, status=400)
         
-        if 'description' in data:
+        if 'short_text_1' in data:
+            line.short_text_1 = data['short_text_1']
+        if 'short_text_2' in data:
+            line.short_text_2 = data['short_text_2']
+        if 'long_text' in data:
+            # long_text is rendered with the `|safe` filter in PDF templates, so it must be
+            # bleach-sanitized. short_text_1/2 and description are always auto-escaped by
+            # Django templates and stored as plain text, so no sanitization is applied there.
+            line.long_text = sanitize_html(data['long_text'])
+        # Regenerate the (secondary) description from the short texts whenever any of
+        # them changed. description never replaces short_text_1.
+        if 'short_text_1' in data or 'short_text_2' in data or 'long_text' in data:
+            line.description = _build_contract_line_description(
+                line.short_text_1, line.short_text_2, line.long_text
+            )
+        elif 'description' in data:
             line.description = data['description']
         if 'unit_id' in data:
             line.unit_id = normalize_foreign_key_id(data['unit_id'])
@@ -1865,6 +1937,9 @@ def ajax_contract_update_line(request, pk, line_id):
                 'id': line.pk,
                 'quantity': str(line.quantity),
                 'unit_price_net': str(line.unit_price_net),
+                'short_text_1': line.short_text_1,
+                'short_text_2': line.short_text_2,
+                'long_text': line.long_text,
                 'description': line.description,
                 'unit_id': line.unit.pk if line.unit else None,
                 'unit_code': line.unit.code if line.unit else '',

--- a/templates/auftragsverwaltung/contracts/detail.html
+++ b/templates/auftragsverwaltung/contracts/detail.html
@@ -409,8 +409,14 @@ Vertrag: {{ contract.name }}
                             <div class="line-content">
                                 <div class="row g-2">
                                     <div class="col-md-12">
-                                        <textarea class="form-control form-control-sm line-description" rows="2" 
-                                                  placeholder="Beschreibung">{{ line.description }}</textarea>
+                                        <label class="form-label-sm">Kurztext 1</label>
+                                        <input type="text" class="form-control form-control-sm line-short-text-1"
+                                               value="{{ line.short_text_1 }}" placeholder="Kurztext 1" maxlength="200">
+                                    </div>
+                                    <div class="col-md-12">
+                                        <label class="form-label-sm">Langtext</label>
+                                        <textarea class="form-control form-control-sm line-long-text" rows="2"
+                                                  placeholder="Langtext">{{ line.long_text }}</textarea>
                                     </div>
                                     <div class="col-md-2">
                                         <label class="form-label-sm">Menge</label>
@@ -565,8 +571,12 @@ Vertrag: {{ contract.name }}
                 <!-- Manual Entry -->
                 <div class="row g-3">
                     <div class="col-md-12">
-                        <label class="form-label">Beschreibung <span class="text-danger">*</span></label>
-                        <textarea class="form-control" id="newLineDescription" rows="2" required></textarea>
+                        <label class="form-label">Kurztext 1 <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control" id="newLineShortText1" maxlength="200" required>
+                    </div>
+                    <div class="col-md-12">
+                        <label class="form-label">Langtext</label>
+                        <textarea class="form-control" id="newLineLongText" rows="2"></textarea>
                     </div>
                     <div class="col-md-3">
                         <label class="form-label">Menge <span class="text-danger">*</span></label>
@@ -771,7 +781,8 @@ $(document).ready(function() {
         $('#addLineModal').modal('show');
         $('#articleSearchInput').val('');
         $('#articleSearchResults').empty();
-        $('#newLineDescription').val('');
+        $('#newLineShortText1').val('');
+        $('#newLineLongText').val('');
         $('#newLineQuantity').val('1.0000');
         $('#newLineUnit').val('');
         $('#newLineUnitPrice').val('0.00');
@@ -805,7 +816,8 @@ $(document).ready(function() {
                                 .data('item', item)
                                 .on('click', function() {
                                     const selectedItem = $(this).data('item');
-                                    $('#newLineDescription').val(selectedItem.short_text_1);
+                                    $('#newLineShortText1').val(selectedItem.short_text_1);
+                                    $('#newLineLongText').val(selectedItem.long_text || '');
                                     $('#newLineQuantity').val('1.0000');
                                     $('#newLineUnitPrice').val(selectedItem.net_price);
                                     $('#newLineTaxRate').val(selectedItem.tax_rate_id);
@@ -856,7 +868,8 @@ $(document).ready(function() {
     
     // Confirm add line
     $('#confirmAddLineBtn').on('click', function() {
-        const description = $('#newLineDescription').val();
+        const shortText1 = $('#newLineShortText1').val();
+        const longText = $('#newLineLongText').val();
         const quantity = normalizeDecimalInput($('#newLineQuantity').val());
         const unitId = $('#newLineUnit').val() || null;
         const unitPrice = normalizeDecimalInput($('#newLineUnitPrice').val());
@@ -864,12 +877,12 @@ $(document).ready(function() {
         const isDiscountable = $('#newLineDiscountable').is(':checked');
         const costType1Id = $('#newLineCostType1').val() || null;
         const costType2Id = $('#newLineCostType2').val() || null;
-        
-        if (!description || !quantity || !unitPrice || !taxRateId) {
+
+        if (!shortText1 || !quantity || !unitPrice || !taxRateId) {
             alert('Bitte füllen Sie alle Pflichtfelder aus.');
             return;
         }
-        
+
         $.ajax({
             url: '{% url "auftragsverwaltung:ajax_contract_add_line" contract.pk %}',
             method: 'POST',
@@ -878,7 +891,8 @@ $(document).ready(function() {
             },
             contentType: 'application/json',
             data: JSON.stringify({
-                description: description,
+                short_text_1: shortText1,
+                long_text: longText,
                 quantity: quantity,
                 unit_id: unitId,
                 unit_price_net: unitPrice,
@@ -925,11 +939,12 @@ $(document).ready(function() {
     });
     
     // Update line on change
-    $(document).on('change', '.line-description, .line-quantity, .line-unit, .line-unit-price, .line-tax-rate, .line-is-discountable, .line-cost-type-1, .line-cost-type-2', function() {
+    $(document).on('change', '.line-short-text-1, .line-long-text, .line-quantity, .line-unit, .line-unit-price, .line-tax-rate, .line-is-discountable, .line-cost-type-1, .line-cost-type-2', function() {
         const lineItem = $(this).closest('.line-item');
         const lineId = lineItem.data('line-id');
 
-        const description = lineItem.find('.line-description').val();
+        const shortText1 = lineItem.find('.line-short-text-1').val();
+        const longText = lineItem.find('.line-long-text').val();
         const quantity = normalizeDecimalInput(lineItem.find('.line-quantity').val());
         const unitId = lineItem.find('.line-unit').val() || null;
         const unitPrice = normalizeDecimalInput(lineItem.find('.line-unit-price').val());
@@ -946,7 +961,8 @@ $(document).ready(function() {
             },
             contentType: 'application/json',
             data: JSON.stringify({
-                description: description,
+                short_text_1: shortText1,
+                long_text: longText,
                 quantity: quantity,
                 unit_id: unitId,
                 unit_price_net: unitPrice,


### PR DESCRIPTION
Automated draft PR opened by the Claude queue worker for Agira item #1053.

Model: Opus
Job: #240

---

## Zusammenfassung

Vertrags- und Rechnungspositionen erhalten jetzt dieselbe Textstruktur:
**Kurztext 1 (`short_text_1`) und Langtext (`long_text`) sind die führenden,
editierbaren Felder**, `description` bleibt als nachrangiges, generiertes
Anzeigefeld erhalten. Damit wird die strukturelle Ursache aus #1044 behoben —
das Rechnungs-Grid rendert `short_text_1`/`long_text`, während die Vertrags-UI
den Text bislang nur in `description` pflegte, sodass erzeugte Rechnungen
optisch leer wirkten. Eine verlustfreie, idempotente Datenmigration überführt
alle Bestands-`ContractLine` von `description` auf die führenden Felder.

## Änderungen

- **Vertrags-UI** (`templates/auftragsverwaltung/contracts/detail.html`): Die
  einzelne „Beschreibung"-Textarea je Position wurde durch getrennte Felder
  **Kurztext 1** (Input, max. 200) und **Langtext** (Textarea) ersetzt — analog
  zum Rechnungs-Detail. Das gilt auch für den „Position hinzufügen"-Dialog. Der
  Item-Picker schreibt `item.short_text_1` nun in **Kurztext 1** (und
  `item.long_text` in **Langtext**) statt in `description`. Die HTMX/AJAX-Aufrufe
  zum Anlegen und Ändern senden `short_text_1`/`long_text` statt `description`.
- **View/Save** (`auftragsverwaltung/views.py`): `ajax_contract_add_line` und
  `ajax_contract_update_line` nehmen `short_text_1`/`short_text_2`/`long_text`
  entgegen und speichern sie; `long_text` wird mit `bleach` sanitisiert.
  `description` wird konsistent aus den Kurztexten generiert (neuer Helper
  `_build_contract_line_description`) und ersetzt `short_text_1` nicht. Für
  Alt-Aufrufer, die nur `description` senden, gibt es einen verlustfreien
  Fallback (Seed in `short_text_1`/`long_text`).
- **Datenmigration** (`0023_migrate_contractline_description_to_texts`):
  Befüllt für jede `ContractLine` mit leerem `short_text_1` und nicht-leerem
  `description` das Feld `short_text_1` aus der ersten Zeile (an Wortgrenze auf
  200 Zeichen gekürzt); bei mehrzeiligem oder zu langem Text wird der
  vollständige `description`-Text zusätzlich nach `long_text` übernommen (nur
  wenn dort noch nichts steht). `description` wird nie verändert. Idempotent
  (bereits gepflegte Zeilen werden übersprungen), Reverse als No-op.
- **Billing** (`services/contract_billing.py`): unverändert — das bestehende
  Feld-zu-Feld-Mapping (`short_text_1`/`short_text_2`/`long_text`/`description`/
  `unit`) liefert nach der Migration sichtbare Texte; per Regressionstest
  abgesichert.
- **Tests**: neue Klasse `ContractLineTextUnificationTestCase` (Billing überträgt
  Kurztext 1/Langtext sichtbar inkl. Retest-Fall „KFZ Miete Hyundai i30 Grau
  LA-HR-1111", zwei Positionen mit unterschiedlichen Steuersätzen/Preisen,
  Reihenfolge und Summen; Migration eines description-only-Bestands verlustfrei
  + Idempotenz). Bestehende Contract-Line-Tests auf die neue Textstruktur
  angepasst.

## Warum / Entscheidungen

- **Kurztext 1 + Langtext als führende Felder**, nicht `description` als Leitfeld,
  weil das Rechnungs-Grid und die PDF-Ausgabe bereits `short_text_1`/`long_text`
  rendern; nur so kommt der Vertragstext in der Rechnung sichtbar an.
- **`description` bleibt erhalten und wird generiert**, nicht ersetzt/gelöscht,
  weil es weiterhin als Fallback/Sekundärfeld dient und die Migration sonst nicht
  verlustfrei wäre.
- **Datenmigration statt Backfill bestehender Rechnungen**: bereits erzeugte
  Rechnungen sind bewusst Snapshots und werden **nicht** rückwirkend geändert,
  um die Snapshot-Integrität zu wahren; nur neue Läufe profitieren.
- **Langtext als einfache Textarea**, nicht als Quill/WYSIWYG-Editor wie teils im
  Rechnungs-Detail, weil für Vertragspositionen ein schlanker, sanitisierter
  Klartext-Langtext genügt und die Datenstruktur (nicht die Editor-Variante) das
  Ziel der Vereinheitlichung ist.
- **Backwards-Fallback für `description`-only-Aufrufe** beibehalten, nicht hart
  auf `short_text_1` umgestellt, weil Alt-Integrationen sonst ohne Textübernahme
  brechen würden — der Fallback ist verlustfrei und seedet nur leere Zielfelder.
- **`makemigrations` erzeugt keine Schema-Migration**, weil die Felder
  (`short_text_1`/`short_text_2`/`long_text`) auf beiden Modellen bereits
  existierten; es fehlten nur UI-Pflege und Bestandsdaten-Migration.

## Test-Hinweise

```bash
python manage.py test auftragsverwaltung.test_contract \
    auftragsverwaltung.test_contract_views \
    auftragsverwaltung.test_decimal_parsing \
    auftragsverwaltung.test_contract_activity_stream \
    --settings=test_settings
python manage.py makemigrations --check --dry-run --settings=test_settings
```

Manueller Retest: Vertrag mit Position „KFZ Miete Hyundai i30 Grau LA-HR-1111"
(Kurztext 1) anlegen, Rechnungslauf starten → der Text erscheint sichtbar in
Kurztext 1 der erzeugten Rechnung; Menge, Netto-Stückpreis, Steuersatz und
Einheit bleiben korrekt.

Hinweis: Im Gesamtlauf der App bestehen einige **vorab vorhandene**, von dieser
Änderung unabhängige Fehler (u. a. `test_ajax_calculate_next_run_date`,
`test_document_create.*`, `test_line_save_hardening.*`, `test_number_range.*`,
`test_timeentry.*`) — auf dem Basis-Branch identisch reproduzierbar.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production contract line text data via a RunPython migration and changes required AJAX fields for manual lines; billing behavior is unchanged but depends on migrated/edited fields being populated correctly.
> 
> **Overview**
> Fixes **empty invoice line text** when billing from contracts: the invoice UI reads **`short_text_1` / `long_text`**, but contract positions were edited only via **`description`**, so generated invoices looked blank (#1044/#1053).
> 
> **Contract UI** (`contracts/detail.html`) now edits **Kurztext 1** and **Langtext** instead of a single Beschreibung field; AJAX add/update sends those fields (article picker fills them from the item).
> 
> **Backend** (`ajax_contract_add_line` / `ajax_contract_update_line`): persists `short_text_1`, `short_text_2`, and sanitized `long_text`; **`description` is generated** via `_build_contract_line_description` and does not replace Kurztext 1. Manual lines require Kurztext 1; legacy payloads with only `description` are seeded into the leading fields.
> 
> **Data migration `0023`**: for lines with empty `short_text_1` and non-empty `description`, fills `short_text_1` (first line, word-boundary truncate to 200) and copies full text to `long_text` when needed; **idempotent**, does not alter `description`.
> 
> Tests cover billing visibility, migration losslessness/idempotency, and AJAX validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c4ca9b2ef42592162e71fb2ae70cd7e2caddf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->